### PR TITLE
Fixed reference to "scopesens" in old "zoom" script, because it is a var...

### DIFF
--- a/config/scripts.cfg
+++ b/config/scripts.cfg
@@ -189,11 +189,11 @@ oldsens = $sensitivity
 
 const zoom [
   if (= $arg1 1) [
-    if (! (=f $sensitivity (scopesens))) [
+    if (! (=f $sensitivity $scopesens)) [
       oldsens = $sensitivity
       // avoid error if using 0.001 as sensitivity
-      newsens = (scopesens)
-      if (> (*f 1 1000) $newsens) [ if (< 1000 $newsens) [ sensitivity (scopesens) ] ]
+      newsens = $scopesens
+      if (> (*f 1 1000) $newsens) [ if (< 1000 $newsens) [ sensitivity $scopesens ] ]
       setscope  1
     ]
   ] [ sensitivity $oldsens; setscope 0 ]


### PR DESCRIPTION
...iable nowadays, and not command.

Bug is visible clearly after typing  "/zoom 1".
