### PR TITLE
This commit fixes removing sleeps in "resetsleep" function.

### DIFF
--- a/source/src/clientgame.cpp
+++ b/source/src/clientgame.cpp
@@ -1687,7 +1687,7 @@ void setfollowplayer(int cn)
     // silently ignores invalid player-cn value passed
     if(players.inrange(cn) && players[cn])
     {
-        if(!(m_teammode && !watchingdemo && team_base(players[cn]->team) != team_base(player1->team)))
+        if(!(m_teammode && player1->team != TEAM_SPECT && !watchingdemo && team_base(players[cn]->team) != team_base(player1->team)))
         {
             player1->followplayercn = cn;
             if(player1->spectatemode == SM_FLY) player1->spectatemode = SM_FOLLOW1ST;


### PR DESCRIPTION
To test this bug make, for example, 3 long-standing sleeps, add checking of number of sleeps before and after existing "loopv(sleep)",
and later  type "/resetsleeps" command in AC - result: 3 sleeps "before" and 1 remains "after".

Explanation by stef: after deleting elements from vectors there are no holes,
so if there were sleeps[0], sleeps[1] and sleeps[2], then after removing sleeps[0] there left
sleeps[0] and sleeps[1], so during next loop cycle this sleeps[0] is neglected (because i=1).

Commit just changes loopv to loopvrev (loop from end to begin).
