### PR TITLE
main: guard against rnd(0) in rndmapname

### DIFF
--- a/source/src/main.cpp
+++ b/source/src/main.cpp
@@ -895,9 +895,13 @@ const char *rndmapname()
 {
     vector<char *> maps;
     listfiles("packages/maps/official", "cgz", maps);
-    char *map = newstring(maps[rnd(maps.length())]);
-    maps.deletearrays();
-    return map;
+    if (maps.length() > 0)
+    {
+        char *map = newstring(maps[rnd(maps.length())]);
+        maps.deletearrays();
+        return map;
+    }
+    else return "";
 }
 
 extern void connectserv(char *, int *, char *);


### PR DESCRIPTION
starting ac_client from the wrong working directory, where
packages/maps/official/*.cgz globs to an empty list, we
trigger a SIGFPE because of rnd(0):

(gdb) r
Program received signal SIGFPE, Arithmetic exception.
0x000000000044d37d in rndmapname () at main.cpp:897
897     char *map = newstring(maps[rnd(maps.length())]);
(gdb) bt
