### PR TITLE
main: autodetect resolution using SDL_SetVideoMode with w/h = 0

### DIFF
--- a/source/src/main.cpp
+++ b/source/src/main.cpp
@@ -77,8 +77,8 @@ bool initwarning(const char *desc, int level, int type)
     return false;
 }
 
-VARF(scr_w, 320, 1024, 10000, initwarning("screen resolution"));
-VARF(scr_h, 200, 768, 10000, initwarning("screen resolution"));
+VARF(scr_w, 0, 0, 10000, initwarning("screen resolution"));
+VARF(scr_h, 0, 0, 10000, initwarning("screen resolution"));
 VARF(colorbits, 0, 0, 32, initwarning("color depth"));
 VARF(depthbits, 0, 0, 32, initwarning("depth-buffer precision"));
 VARF(stencilbits, 0, 0, 32, initwarning("stencil-buffer precision"));


### PR DESCRIPTION
This is an initial attempt to use SDL_SetVideoMode with w and h set to 0 to autodetect the native screen resolution.
