### PR TITLE
Patch adds flags reset in ctf/htf mode after "shuffleteams".

### DIFF
--- a/source/src/server.cpp
+++ b/source/src/server.cpp
@@ -1690,6 +1690,12 @@ void shuffleteams(int ftr = FTR_AUTOTEAM)
             team = !team;
         }
     }
+
+    if(m_ctf || m_htf)
+    {
+        ctfreset();
+        sendflaginfo();
+    }
 }
 
 bool balanceteams(int ftr)  // pro vs noobs never more


### PR DESCRIPTION
Nowadays after teams rearrangemend flags are only dropped and don't return to base.
