### PR TITLE
Fix of wrong "alive" status in scoreboard.

### DIFF
--- a/source/src/clientgame.cpp
+++ b/source/src/clientgame.cpp
@@ -173,7 +173,6 @@ void newname(const char *name)
         addmsg(SV_SWITCHNAME, "rs", player1->name);
     }
     else conoutf(_("your name is: %s"), player1->name);
-    //alias(_("curname"), player1->name); // WTF? stef went crazy - this isn't something to translate either.
     alias("curname", player1->name);
 }
 

--- a/source/src/scoreboard.cpp
+++ b/source/src/scoreboard.cpp
@@ -206,8 +206,8 @@ void renderscore(playerent *d)
     const char *status = "";
     string lagping;
     static color localplayerc(0.2f, 0.2f, 0.2f, 0.2f);
-    if(d->clientrole==CR_ADMIN) status = d->state==CS_DEAD ? "\f7" : "\f3";
-    else if(d->state==CS_DEAD) status = "\f4";
+    if(d->clientrole==CR_ADMIN) status = d->state!=CS_ALIVE ? "\f7" : "\f3";
+    else if(d->state!=CS_ALIVE) status = "\f4";
     if (team_isspect(d->team)) copystring(lagping, "SPECT");
     else if (d->state==CS_LAGGED || (d->ping > 999 && d->plag > 99)) copystring(lagping, "LAG");
     else


### PR DESCRIPTION
This commit fixes the issue: https://github.com/assaultcube/AC/issues/21
Player in spectate mode isn't dead, so when he switches from spectate to active mode, he is still non-dead.
Therefore d->state=="CS_DEAD" doesn't work in such cases.
This commit removes also some aimless line.
