### PR TITLE
Fix of wrong stats of pistol's ammo on HUD, when player holds nade and a...

### DIFF
--- a/source/src/renderhud.cpp
+++ b/source/src/renderhud.cpp
@@ -1086,6 +1086,7 @@ void gl_drawhud(int w, int h, int curfps, int nquads, int curvert, bool underwat
             {
                 glMatrixMode(GL_MODELVIEW);
                 if (p->weaponsel->type!=GUN_GRENADE) p->weaponsel->renderstats();
+                else if (p->prevweaponsel->type==GUN_AKIMBO && !p->akimbo) p->weapons[GUN_PISTOL]->renderstats();
                 else p->prevweaponsel->renderstats();
                 if(p->mag[GUN_GRENADE]) p->weapons[GUN_GRENADE]->renderstats();
                 glMatrixMode(GL_PROJECTION);


### PR DESCRIPTION
...kimbo disappears.

To test the bug: take akimbo, take grenade, press "g"  and wait for akimbo disappearing.
Then stats on HUD shows, that player has pistol with 0 ammo, instead of full magazine.
