### PR TITLE
Cleanedit Mode

### DIFF
--- a/config/docs.cfg
+++ b/config/docs.cfg
@@ -157,6 +157,10 @@ docargument [A] [the alias to check for] [] [0];
 docargument [B] [the block of code to ensure that the alias contains] [] [0];
 docexample [checkinit mapstartalways] [Output: if alias mapstartalways does not exist, this command initializes it.];
 docexample [checkinit mapstartalways [ echo New map, good luck! ]] [Output: if alias mapstartalways does not exist, it is initialized, and if the block of code "[ echo New map, good luck! ]" does not exist within the aliases contents, this command adds it.];
+docident [cleanedit] [turns on/off clean edit mode];
+docargument [V] [0(off)...1(on)] [] [0];
+docremark [While editing in clean edit mode, objects/guides not normally visible remain invisible]
+docremark [i.e. The grid guidelines, selection borders, entity sparkles, clips, playerstart arrows are hidden]
 docident [concat] [Concatenates multiple strings with spaces inbetween.];
 docargument [S] [the first string] [] [0];
 docargument [...] [collection of strings to concatenate] [] [1];
@@ -370,6 +374,7 @@ docexample [echo (testchar B 4)] [Output: 1 // It is a uppercase A-Z character];
 docexample [echo (testchar , 5)] [Output: 1 // It is a printable character];
 docexample [echo (testchar . 6)] [Output: 1 // It is a punctuation character];
 docexample [echo (testchar " " 7)] [Output: 1 // It is a whitespace character];
+docident [togglecleanedit] [inverses the on/off state of cleanedit];
 docident [tolower] [Converts a string to all lowercase characters.];
 docargument [S] [a string] [] [0];
 docexample [echo (tolower HELLO)] [Output: hello];

--- a/source/src/editing.cpp
+++ b/source/src/editing.cpp
@@ -8,6 +8,9 @@ bool editmode = false;
 // invariant: all code assumes that these are kept inside MINBORD distance of the edge of the map
 // => selections are checked when they are made or when the world is reloaded
 
+VAR(cleanedit, 0, 0, 1); // hides everything in edit mode you can't see in regular mode
+COMMANDF(togglecleanedit, "", () {cleanedit = !cleanedit;}); // CS toggle for above
+
 vector<block> sels;
 
 #define loopselxy(sel, b) { makeundo(sel); loop(x,(sel).xs) loop(y,(sel).ys) { sqr *s = S((sel).x+x, (sel).y+y); b; } remip(sel); }
@@ -176,6 +179,8 @@ FVAR(tagcliplinewidth, 0.2, 1, 3);
 
 void cursorupdate()                                     // called every frame from hud
 {
+    if (cleanedit) return;
+
     flrceil = ((int)(camera1->pitch>=0))*2;
     int cyaw = ((int) camera1->yaw) % 180;
     editaxis = editmode ? (fabs(camera1->pitch) > 65 ? 13 : (cyaw < 45 || cyaw > 135 ? 12 : 11)) : 0;

--- a/source/src/entities.cpp
+++ b/source/src/entities.cpp
@@ -5,6 +5,8 @@
 VAR(showclips, 0, 1, 1);
 VAR(showmodelclipping, 0, 0, 1);
 
+extern bool cleanedit;
+
 vector<entity> ents;
 vector<int> eh_ents; // edithide entities
 const char *entmdlnames[] =
@@ -27,6 +29,8 @@ const char *entmdlnames[] =
 
 void renderclip(entity &e)
 {
+    if (cleanedit) return;
+
     float xradius = max(float(e.attr2), 0.1f), yradius = max(float(e.attr3), 0.1f);
     vec bbmin(e.x - xradius, e.y - yradius, float(S(e.x, e.y)->floor+e.attr1)),
         bbmax(e.x + xradius, e.y + yradius, bbmin.z + max(float(e.attr4), 0.1f));
@@ -125,7 +129,8 @@ COMMAND(seteditshow, "s");
 
 void renderentarrow(const entity &e, const vec &dir, float radius)
 {
-    if(radius <= 0) return;
+    if(cleanedit || radius <= 0) return;
+
     float arrowsize = min(radius/8, 0.5f);
     vec epos(e.x, e.y, e.z);
     vec target = vec(dir).mul(radius).add(epos), arrowbase = vec(dir).mul(radius - arrowsize).add(epos), spoke;
@@ -157,7 +162,7 @@ void renderentarrow(const entity &e, const vec &dir, float radius)
 void renderentities()
 {
     int closest = editmode ? closestent() : -1;
-    if(editmode && !reflecting && !refracting && !stenciling)
+    if(editmode && !reflecting && !refracting && !stenciling && !cleanedit)
     {
         static int lastsparkle = 0;
         if(lastmillis - lastsparkle >= 20)

--- a/source/src/renderhud.cpp
+++ b/source/src/renderhud.cpp
@@ -2,6 +2,8 @@
 
 #include "cube.h"
 
+extern bool cleanedit;
+
 void drawicon(Texture *tex, float x, float y, float s, int col, int row, float ts)
 {
     if(tex && tex->xs == tex->ys) quad(tex->id, x, y, s, ts*col, ts*row, ts);
@@ -280,6 +282,8 @@ COMMAND(loadcrosshair, "ss");
 
 void drawcrosshair(playerent *p, int n, color *c, float size)
 {
+    if (cleanedit && editmode) return;
+
     Texture *crosshair = crosshairs[n];
     if(!crosshair)
     {
@@ -886,7 +890,22 @@ void gl_drawhud(int w, int h, int curfps, int nquads, int curvert, bool underwat
     char *infostr = editinfo();
     int commandh = 1570 + FONTH;
     if(command) commandh -= rendercommand(20, 1570, VIRTW);
-    else if(infostr) draw_text(infostr, 20, 1570);
+
+    else if(infostr)
+    {
+        if (cleanedit) // smaller text
+        {
+            glPushMatrix();
+            glLoadIdentity();
+            glOrtho(0, VIRTW*2, VIRTH*2, 0, -1, 1);
+            glScalef(1.0, 1.0, 1.0); //set scale
+            draw_text(infostr, 48, VIRTH*2 - 3*FONTH);
+            glPopMatrix();
+        }
+        else
+        draw_text(infostr, 20, 1570);
+    }
+
     else if(targetplayer && showtargetname) draw_text(colorname(targetplayer), 20, 1570);
     glLoadIdentity();
     glOrtho(0, VIRTW*2, VIRTH*2, 0, -1, 1);


### PR DESCRIPTION
Commands and documentation for /cleanedit and /togglecleanedit.

Hides ALL editing related graphics to edit with unobstructed view of
cube/entity changes.

cleanedit is the user VAR and can be fetched in CS. togglecleanedit is
the bindable command and the intended way to toggle the value of
$cleanedit.
