### PR TITLE
Move AC's home dir in "My Games" on Windows

### DIFF
--- a/assaultcube_release.bat
+++ b/assaultcube_release.bat
@@ -1,1 +1,1 @@
-start bin_win32\ac_client.exe "--home=?MYDOCUMENTS?\AssaultCube_v1.2" --init %1 %2 %3 %4 %5
+start bin_win32\ac_client.exe "--home=?MYDOCUMENTS?\My Games\AssaultCube_v1.2" --init %1 %2 %3 %4 %5


### PR DESCRIPTION
The title is saying pretty much everything. Move it in "My Games" to keep the document directory structure clean. 

Side note: "My Games" is also the home dir for a lot of other games, including all other Cube (2)/Tesseract engine based games, at least the ones who are still getting maintanced and which I know personally. 