### PR TITLE
Pass used gun from server to dodamage

### DIFF
--- a/source/src/clients2c.cpp
+++ b/source/src/clients2c.cpp
@@ -813,7 +813,7 @@ void parsemessages(int cn, playerent *d, ucharbuf &p, bool demo = false)
                 if(!target || !actor) break;
                 target->armour = armour;
                 target->health = health;
-                dodamage(damage, target, actor, -1, type==SV_GIBDAMAGE, false);
+                dodamage(damage, target, actor, gun, type==SV_GIBDAMAGE, false);
                 actor->pstatdamage[gun]+=damage; //NEW
                 break;
             }


### PR DESCRIPTION
I don't see a reason why we shoudn't give out the gun to the client. When custom gun messages were implemented this was somehow not passed to dodamage. 80c024f151878facc3d4476e7631d813cc4c0414
But my guess would be that the onHit alias was not implemented back then and besides for local damage which passes the gun to dodamage correctly it was probably not needed?