### PR TITLE
New world renderer

### DIFF
--- a/source/codeblocks/AssaultCube.cbp
+++ b/source/codeblocks/AssaultCube.cbp
@@ -366,6 +366,10 @@
 			<Option target="default" />
 			<Option target="debug" />
 		</Unit>
+		<Unit filename="../src/newworldrender.cpp">
+			<Option target="default" />
+			<Option target="debug" />
+		</Unit>
 		<Unit filename="../src/oggstream.cpp">
 			<Option target="default" />
 			<Option target="debug" />

--- a/source/src/Makefile
+++ b/source/src/Makefile
@@ -22,7 +22,7 @@ PLATFORM_PREFIX=native
 
 ifeq ($(ACDEBUG),yes)
 	CXXFLAGS= -O0
-	override CXXFLAGS+= -g -D_DEBUG
+	override CXXFLAGS+= -g3 -D_DEBUG
 endif
 
 ifneq (,$(findstring clang,$(CXX)))
@@ -69,6 +69,7 @@ CLIENT_OBJS= \
 	log.o \
 	main.o \
 	menus.o \
+	newworldrender.o \
 	oggstream.o \
 	openal.o \
 	packetqueue.o \
@@ -267,6 +268,7 @@ main.o: entity.h world.h command.h varray.h vote.h console.h protos.h
 main.o: jpegenc.h
 menus.o: cube.h platform.h tools.h geom.h model.h protocol.h sound.h weapon.h
 menus.o: entity.h world.h command.h varray.h vote.h console.h protos.h
+newworldrender.o: cube.h protos.h
 oggstream.o: cube.h platform.h tools.h geom.h model.h protocol.h sound.h
 oggstream.o: weapon.h entity.h world.h command.h varray.h vote.h console.h
 oggstream.o: protos.h

--- a/source/src/editing.cpp
+++ b/source/src/editing.cpp
@@ -135,7 +135,6 @@ char *editinfo()
     return info;
 }
 
-
 // multiple sels
 
 // add a selection to the list

--- a/source/src/main.cpp
+++ b/source/src/main.cpp
@@ -626,7 +626,7 @@ void resetgl()
     c2skeepalive();
     preload_mapmodels();
     c2skeepalive();
-    postregenworldvbos();
+    postregenworldvbos(true);
 }
 
 COMMAND(resetgl, "");

--- a/source/src/main.cpp
+++ b/source/src/main.cpp
@@ -626,6 +626,7 @@ void resetgl()
     c2skeepalive();
     preload_mapmodels();
     c2skeepalive();
+    postregenworldvbos();
 }
 
 COMMAND(resetgl, "");

--- a/source/src/newworldrender.cpp
+++ b/source/src/newworldrender.cpp
@@ -592,7 +592,8 @@ struct worldmesh
             coord2d no = NEIGHBOUR_OFFSETS[i];
             int xo = x + no.x*size;
             int yo = y + no.y*size;
-            if(OUTBORD(xo, yo) || OUTBORD(x, y)) continue;
+            //if(OUTBORD(xo, yo) || OUTBORD(x, y)) continue;
+            if(x == 0 || y == 0 || x == ssize-1 || y == ssize-1) continue;
 
             // corner heights - elevation at the starting and finishing corner
             // upper edge for lower and solid walls, lower edge for upper walls
@@ -846,9 +847,9 @@ double lighterrorscore(int x1, int y1, int x2, int y2, bool edge=false)
         double xf = wf * j, yf = hf * k, xs = 1.0 - xf, ys = 1.0 - yf;
         double r, g, b;
         #define INTERPOLATE(c) c = xs*ys*cornercolors[TOP_LEFT].c + xf*ys*cornercolors[TOP_RIGHT].c + xs*yf*cornercolors[BOTTOM_LEFT].c + xf*yf*cornercolors[BOTTOM_RIGHT].c;
-        #define ERROR(c) score += SCORE_FACTOR*fabs(s->c - c);
+        #define LCERROR(c) score += SCORE_FACTOR*fabs(s->c - c);
         INTERPOLATE(r); INTERPOLATE(g); INTERPOLATE(b);
-        ERROR(r); ERROR(g); ERROR(b);
+        LCERROR(r); LCERROR(g); LCERROR(b);
     }
     return sqrt(score);
 }
@@ -905,7 +906,7 @@ void cornertris(worldmesh *wm, int x1, int y1, int bsize)
         }
     }
     // No corners that hug the very edges of the map. Thanks MINBORD!
-    if(OUTBORDRAD(x1, y1, bsize)) return;
+    if(OUTBORD(x1, y1) || OUTBORD(x1+bsize, y1+bsize)) return;
 
     // Do it like the original
     //  w
@@ -1065,8 +1066,6 @@ void wallmeshqt(worldmesh *wm, int x1, int y1, int bsize, bool ceil)
         {
             bool edge = (x == xbeg) || (x == xend-1) || (y == ybeg) || (y == yend-1);
             sqr const *s = S(x, y);
-            // Check if lighterror is exceeded - never for skymap
-            //bool lightfail = (ceil ? prev->utex : prev->wtex) != 0 && lighterr > maxlighterr;
 
             bool texfail = false;
             bool typefail = s->type != prev->type || (s->type != SPACE && s->type != SOLID);

--- a/source/src/newworldrender.cpp
+++ b/source/src/newworldrender.cpp
@@ -928,11 +928,12 @@ void cornertris(worldmesh *wm, int x1, int y1, int bsize)
     else
     {
         // No properly placed solids around - form a non-solid corner
+
         normalwall = false;
         bool wv = w->ceil-w->floor < v->ceil-v->floor;
 
+        sqr const *s2 = NULL; // Cube adjacent to the corner, used for lower wall tex
         int floor2, ceil2, ftex2, ctex2, wcorner1, wcorner2, fcorner1, fcorner2;
-        sqr const *s2 = NULL;
 
         if(z->ceil-z->floor < t->ceil-t->floor)
         {
@@ -950,6 +951,13 @@ void cornertris(worldmesh *wm, int x1, int y1, int bsize)
         ceil2 = 4 * s2->ceil;
         fcorner2 = opposingcorner(fcorner1);
         wcorner2 = opposingcorner(wcorner1);
+
+        // Cap the floor/ceil values such that the corner walls don't
+        // have a negative height; ceilings with negative heights are
+        // essentially inverted (they face the wrong way) and cause
+        // artifacting on some bugged maps.
+        floor2 = min(floor, floor2);
+        ceil2 = max(ceil, ceil2);
 
         wm->wallquad(x1, y1, floor, floor, floor2, floor2, wcorner2, wcorner1, s->wtex, bsize); // Lower wall
         wm->wallquad(x1, y1, ceil2, ceil2, ceil, ceil, wcorner2, wcorner1, s->utex, bsize); // Upper wall

--- a/source/src/newworldrender.cpp
+++ b/source/src/newworldrender.cpp
@@ -685,12 +685,12 @@ struct worldmesh
         checkglerrors();
         b.bind_buffers();
         vector<vertex> *vs = verts + b.tex;
-        glBufferData(GL_ARRAY_BUFFER, sizeof(vertex) * vs->length(), vs->getbuf(), GL_STATIC_DRAW);
+        GLenum usage = editmode ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW;
+        glBufferData(GL_ARRAY_BUFFER, sizeof(vertex) * vs->length(), vs->getbuf(), usage);
         vector<arrayindex> *evec = vertindices + b.tex;
         b.elemcount = evec->length();
         startindices[b.tex].add(b.elemcount);
         b.blockstarts = startindices[b.tex];
-        GLenum usage = editmode ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW;
         if(vs->length() <= 65535)
         {
             // Use short indices if less than 64k verts
@@ -766,14 +766,17 @@ int checkglerrors()
         const char *str = "unknown";
         switch(error)
         {
-        case GL_NO_ERROR: str = "No error"; break;
-        case GL_INVALID_ENUM: str = "Invalid enum"; break;
-        case GL_INVALID_VALUE: str = "Invalid value"; break;
-        case GL_INVALID_OPERATION: str = "Invalid operation"; break;
-        case GL_STACK_OVERFLOW: str = "Stack overflow"; break;
+        case GL_NO_ERROR: str = "no error"; break;
+        case GL_INVALID_ENUM: str = "invalid enum"; break;
+        case GL_INVALID_VALUE: str = "invalid value"; break;
+        case GL_INVALID_OPERATION: str = "invalid operation"; break;
+        case GL_STACK_OVERFLOW: str = "stack overflow"; break;
 
         }
-        printf("OpenGL error: %s\n", str);
+        printf("[%d] OpenGL error: %s\n", SDL_GetTicks(), str);
+        fflush(stdout);
+        fflush(stderr);
+        //abort();
     }
     return errcount;
 }
@@ -1359,7 +1362,6 @@ void rendertrissky()
         glDisable(GL_TEXTURE_2D);
         glDisableClientState(GL_TEXTURE_COORD_ARRAY);
         glEnableClientState(GL_VERTEX_ARRAY);
-        glEnableClientState(GL_ARRAY_BUFFER);
         glEnableClientState(GL_COLOR_ARRAY);
         texbatches[0].pre();
         glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
@@ -1378,7 +1380,6 @@ void render_world_new()
     if(!visibleblocks.length()) goto done;
 
     glEnable(GL_TEXTURE_2D);
-    glEnableClientState(GL_ARRAY_BUFFER);
     glEnableClientState(GL_VERTEX_ARRAY);
     glEnableClientState(GL_COLOR_ARRAY);
     glEnableClientState(GL_TEXTURE_COORD_ARRAY);
@@ -1391,12 +1392,10 @@ void render_world_new()
     }
 
     done:
-    // Is this really necessary?
-    glDisableClientState(GL_ARRAY_BUFFER);
+    glDisableClientState(GL_VERTEX_ARRAY);
     glDisableClientState(GL_COLOR_ARRAY);
     glDisableClientState(GL_TEXTURE_COORD_ARRAY);
 
-    // This is really necessary.
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 }

--- a/source/src/newworldrender.cpp
+++ b/source/src/newworldrender.cpp
@@ -93,8 +93,8 @@ double blockdist(int);
  */
 struct visibleblockspan
 {
-    
-    visibleblockspan(int start=-1);    
+
+    visibleblockspan(int start=-1);
 
     /// First render block of this span
     int start;
@@ -107,7 +107,7 @@ struct visibleblockspan
 
     /// Distance to the nearest block
     float nearestdist;
-    
+
     /**
      * @brief Update nearest render block and distance if necessary
      */
@@ -120,7 +120,7 @@ struct visibleblockspan
             nearestdist = dist;
         }
     }
-    
+
     /**
      * @brief Find the render block in this span closest to the camera
      */
@@ -131,18 +131,18 @@ struct visibleblockspan
             updatenearest(i);
         }
     }
-    
+
     /**
      * @brief Get the number of vertices in the given batch in this span.
      */
     int vertcount(texbatch const* t);
-    
+
 };
 
 
-visibleblockspan::visibleblockspan(int start) : 
+visibleblockspan::visibleblockspan(int start) :
     start(start), count(1), nearestblock(-1), nearestdist(1e16)
-{ 
+{
     if(start >= 0)
     {
         updatenearest(start);
@@ -168,19 +168,19 @@ DEBUGCODE(VAR(cyclevbs, 0, 0, 1));
 
 class texbatch
 {
-    
+
     // Private list of visible block spans
     vector<visibleblockspan> spans;
-    
+
 public:
-    
+
     GLuint vertexbo;
     GLuint elembo;
     int elemtype;
     int tex;
     int elemcount;
     vector<int> blockstarts;
-    
+
 
     texbatch() : vertexbo(0), elembo(0), tex(0), elemcount(0), elemtype(0) {}
 
@@ -249,7 +249,7 @@ public:
         glDrawElements(GL_TRIANGLES, elemcount, elemtype, 0);
         wdrawcalls += 1;
     }
-    
+
     /**
      * @brief Render all geometry in visible blocks.
      */
@@ -257,7 +257,7 @@ public:
     {
         int spancount = visibleblockspans.length();
         bool ready = false;
-        
+
         spans = visibleblockspans;
         spans.sort<visibleblockspan>(nearestvisibleblockspancmp);
         
@@ -285,7 +285,7 @@ public:
             wdrawcalls += 1;
         }
     }
-    
+
 };
 
 int visibleblockspan::vertcount(const texbatch* t)
@@ -536,13 +536,13 @@ struct worldmesh
     {
         vertindices[tex].add(vertex_index(x, y, h, tex, xo, yo, wall));
     }
-    
+
     void flattri(int x, int y, int h, int tex, int corner, bool ceil, int size=1)
     {
         int corners[3];
         corners[0] = nextcorner(corner, !ceil);
         loopi(2) corners[i+1] = nextcorner(corners[i], ceil);
-        
+
         loopi(3)
         {
             int xo, yo;
@@ -551,9 +551,9 @@ struct worldmesh
         }
         //int xo, yo;
         //corner_offsets(corner, xo, yo);
-        
-        
-        
+
+
+
         /*
         switch(corner)
         {
@@ -578,7 +578,7 @@ struct worldmesh
                 addvert(x+size, y,      h, tex);
                 break;
         }
-        if(ceil) 
+        if(ceil)
         {
             int i = vertindices[tex].length() - 1;
             swap(vertindices[tex][i], vertindices[tex][i-1]);
@@ -902,10 +902,10 @@ bool unifiable(sqr const *s1, sqr const *s2, bool ceil)
 
 /**
  * @brief Get the corner corresponding to the given side
- * 
+ *
  * Gets the corner opposing the corner which joins the given side
  * and the side next to it in counterclockwise direction.
- * 
+ *
  * Helper function for cornertris.
  */
 int cornerfromside(int s)
@@ -916,7 +916,7 @@ int cornerfromside(int s)
         case TOP:    return BOTTOM_LEFT;
         case RIGHT:  return TOP_LEFT;
         case BOTTOM: return TOP_RIGHT;
-    }  
+    }
 }
 
 /**
@@ -926,7 +926,7 @@ void cornertris(worldmesh *wm, int x1, int y1, int bsize)
 {
     // TODO this is a lot of code for a simple thing, the old renderer
     // seemed to get away with a lot less... do something about it?
-    
+
     // Check if the bsize*bsize block at x1,y1 (topleft corner)
     // is a complete corner
     if(bsize == 0) return;
@@ -951,8 +951,8 @@ void cornertris(worldmesh *wm, int x1, int y1, int bsize)
     if(x1 == 0 || y1 == 0 || x1+bsize >= ssize || y1+bsize == ssize) return;
     int corner; // The corner of the block which contains the "solid" part
     sqr const *s = S(x1, y1);
-    
-    
+
+
     // Try making corners with solids
     loopi(NUM_SIDES)
     {
@@ -964,7 +964,6 @@ void cornertris(worldmesh *wm, int x1, int y1, int bsize)
         {
             int floor = 4 * s->floor;
             int ceil = 4 * s->ceil;
-            int wtex = adj1->wtex;
             int ftex = s->ftex;
             int ctex = s->ctex;
             switch(i)
@@ -972,36 +971,36 @@ void cornertris(worldmesh *wm, int x1, int y1, int bsize)
                 case LEFT:
                     loopi(bsize)
                     {
-                        wm->wallquad(x1+i, y1+bsize-i-1, floor, floor, 
+                        wm->wallquad(x1+i, y1+bsize-i-1, floor, floor,
                                      ceil, ceil,
-                                     BOTTOM_LEFT, TOP_RIGHT, wtex);
+                                     BOTTOM_LEFT, TOP_RIGHT, S(x1,y1-bsize)->wtex);
                     }
                     corner = BOTTOM_RIGHT;
                     break;
                 case TOP:
                     loopi(bsize)
                     {
-                        wm->wallquad(x1+i, y1+i, floor, floor, 
+                        wm->wallquad(x1+i, y1+i, floor, floor,
                                      ceil, ceil,
-                                     TOP_LEFT, BOTTOM_RIGHT, wtex);
+                                     TOP_LEFT, BOTTOM_RIGHT, S(x1,y1-bsize)->wtex);
                     }
                     corner = BOTTOM_LEFT;
                     break;
                 case RIGHT:
                     loopi(bsize)
                     {
-                        wm->wallquad(x1+bsize-i-1, y1+i, floor, floor, 
+                        wm->wallquad(x1+bsize-i-1, y1+i, floor, floor,
                                      ceil, ceil,
-                                     TOP_RIGHT, BOTTOM_LEFT, wtex);
+                                     TOP_RIGHT, BOTTOM_LEFT, S(x1,y1+bsize)->wtex);
                     }
                     corner = TOP_LEFT;
                     break;
                 case BOTTOM:
                     loopi(bsize)
                     {
-                        wm->wallquad(x1+bsize-i-1, y1+bsize-i-1, floor, floor, 
+                        wm->wallquad(x1+bsize-i-1, y1+bsize-i-1, floor, floor,
                                      ceil, ceil,
-                                     BOTTOM_RIGHT, TOP_LEFT, wtex);
+                                     BOTTOM_RIGHT, TOP_LEFT, S(x1,y1+bsize)->wtex);
                     }
                     corner = TOP_RIGHT;
                     break;
@@ -1012,19 +1011,19 @@ void cornertris(worldmesh *wm, int x1, int y1, int bsize)
             return;
         }
     }
-    
+
     // No appropriately placed solids around - form a "non-solid" corner.
-    
+
     // Find the best side to form the corner to both the floor
     // and the ceiling. Best side is the side for which the corner
     // joining in and the next side (in clockwise direction) protrudes
     // furthest from the appropriate surface.
     int floorside = 0, ceilside = 0;
-    
+
     // Heights of the two cubes which will be used to form the corner.
     // Used for selecting the best side.
     int floorheights[2], ceilheights[2];
-    loopi(2) 
+    loopi(2)
     {
         floorheights[i] = -200;
         ceilheights[i] = 200;
@@ -1045,7 +1044,7 @@ void cornertris(worldmesh *wm, int x1, int y1, int bsize)
             curceiltotal += ceilheights[j];
             newceiltotal += adj[j]->ceil;
         }
-        loopj(2) 
+        loopj(2)
         {
             sqr const *a = adj[j];
             if(!SOLID(a) && newfloortotal > curfloortotal)
@@ -1055,7 +1054,7 @@ void cornertris(worldmesh *wm, int x1, int y1, int bsize)
                 break;
             }
         }
-        loopj(2) 
+        loopj(2)
         {
             sqr const *a = adj[j];
             if(!SOLID(a) && newceiltotal < curceiltotal)
@@ -1066,18 +1065,18 @@ void cornertris(worldmesh *wm, int x1, int y1, int bsize)
             }
         }
     }
-    
+
     int fcorner = cornerfromside(floorside);
     int ccorner = cornerfromside(ceilside);
     sqr const *fadj = S(x1, y1+(CT(fcorner)?-1:1)*bsize);
     sqr const *cadj = S(x1, y1+(CT(ccorner)?-1:1)*bsize);
 
-    
+
     sqr const *adj = NULL;
-    
+
     // Use floor cubes to form the corner
     bool floorcorner = int(s->floor)-int(fadj->floor) > int(cadj->ceil)-int(s->ceil);
-    
+
     if(floorcorner)
     {
         corner = fcorner;
@@ -1088,31 +1087,31 @@ void cornertris(worldmesh *wm, int x1, int y1, int bsize)
         corner = ccorner;
         adj = cadj;
     }
-    
+
     // Generate flats matching the surrounding floor & ceil
     wm->flattri(x1, y1, 4*adj->floor, adj->ftex, corner, false, bsize);
     wm->flattri(x1, y1, 4*adj->ceil, adj->ctex, corner, true, bsize);
-    
+
     // Generate flats for the corner itself
     wm->flattri(x1, y1, 4*s->floor, s->ftex, opposingcorner(corner), false, bsize);
     wm->flattri(x1, y1, 4*s->ceil, s->ctex, opposingcorner(corner), true, bsize);
-    
+
     int wcorner1 = nextcorner(corner);
     int wcorner2 = nextcorner(opposingcorner(corner));
-    
-    bool flip = wcorner1 == TOP_LEFT || wcorner1 == BOTTOM_RIGHT;    
-    
+
+    bool flip = wcorner1 == TOP_LEFT || wcorner1 == BOTTOM_RIGHT;
+
     int c = bsize - 1;
     // Lower walls
     int flheight = 4 * adj->floor, fuheight = 4 * s->floor;
     loopi(bsize)
-        wm->wallquad((flip ? x1+i : x1+c-i), y1+i, flheight, flheight, fuheight, fuheight, 
+        wm->wallquad((flip ? x1+i : x1+c-i), y1+i, flheight, flheight, fuheight, fuheight,
                      wcorner1, wcorner2, s->wtex);
-    
+
     // Upper walls
     int clheight = 4 * s->ceil, cuheight = 4 * adj->ceil;
     loopi(bsize)
-        wm->wallquad((flip ? x1+i : x1+c-i), y1+i, clheight, clheight, cuheight, cuheight, 
+        wm->wallquad((flip ? x1+i : x1+c-i), y1+i, clheight, clheight, cuheight, cuheight,
                      wcorner1, wcorner2, s->utex);
 
 }
@@ -1148,7 +1147,7 @@ void flatmeshqt(worldmesh *wm, int x1, int y1, int bsize, bool ceil)
             lighterr += abs(s->r - prev->r) + abs(s->g - prev->g) + abs(s->b - prev->b);
             // Check if lighterror is exceeded - never for skymap
             bool lightfail = (ceil ? prev->ctex : prev->ftex) != 0 && lighterr > maxlighterr;
-            
+
             if(lightfail || !unifiable(prev, s, ceil))
             {
                 int hbsize = bsize / 2;

--- a/source/src/newworldrender.cpp
+++ b/source/src/newworldrender.cpp
@@ -1143,7 +1143,7 @@ void findvisibleblocks()
 
 bool iswatercube(sqr const *s)
 {
-    return !SOLID(s) && (waterlevel >= s->floor);
+    return !SOLID(s) && (waterlevel >= s->floor - (s->type == FHF ? 0.25f * s->vdelta : 0));
 }
 
 /**

--- a/source/src/newworldrender.cpp
+++ b/source/src/newworldrender.cpp
@@ -1,0 +1,1109 @@
+
+#include "cube.h"
+#include "tools.h"
+
+VARP(usenewworldrenderer, 0, 0, 1);
+
+//TODO ogl functions need to go to a better place.
+PFNGLBINDBUFFERPROC glBindBuffer = NULL;
+PFNGLBUFFERDATAPROC glBufferData = NULL;
+PFNGLGENBUFFERSPROC glGenBuffers = NULL;
+PFNGLDELETEBUFFERSPROC glDeleteBuffers = NULL;
+
+#define GETPROCADDR(type, name) reinterpret_cast<type>(SDL_GL_GetProcAddress(name))
+
+bool glprocsloaded = false;
+
+/**
+ * @brief set up pointers to OpenGL functions if necessary.
+ */
+bool loadglprocs()
+{
+    if(glprocsloaded) return true;
+    glBindBuffer = GETPROCADDR(PFNGLBINDBUFFERPROC, "glBindBuffer");
+    glBufferData = GETPROCADDR(PFNGLBUFFERDATAPROC, "glBufferData");
+    glGenBuffers = GETPROCADDR(PFNGLGENBUFFERSPROC, "glGenBuffers");
+    glDeleteBuffers = GETPROCADDR(PFNGLDELETEBUFFERSPROC, "glDeleteBuffers");
+    return glprocsloaded = glBindBuffer && glBufferData && glGenBuffers && glDeleteBuffers;
+}
+
+#define DEBUGCOND (1) // TODO allow debugging to be turned off
+
+enum { FLAT = 0, WALL_LEFTTORIGHT, WALL_TOPTOBOTTOM };
+
+struct vertexpoint
+{
+    ushort x;
+    ushort y;
+    short height; // quarter-cube units to accommodate vdeltas
+    short wall;
+
+    vertexpoint(int x=0, int y=0, int h=0, int wall=FLAT):
+        x(x), y(y), height(h), wall(wall)
+    {  }
+
+    bool operator==(const vertexpoint &o) const
+    {
+        return x == o.x && y == o.y && height == o.height && (!wall == !o.wall);
+    }
+
+};
+
+// TODO this hash looks shit, steal one from somewhere...
+uint hthash(const vertexpoint &vp)
+{
+    uint x = vp.x, y = vp.y, h = vp.height, c = vp.wall;
+    uint hash = x | y << 12 | h << 24;
+    hash *= (1 + vp.wall);
+    return hash;
+}
+
+bool htcmp(const vertexpoint &vp1, const vertexpoint &vp2)
+{
+    return vp1 == vp2;
+}
+
+#define VERTCOLOURS(v, s) { (v).r = (s).r; (v).g = (s).g; (v).b = (s).b; (v).a = 255; }
+
+
+#define GLBUFOFF(n) static_cast<GLvoid *>(static_cast<char *>(0) + (n))
+
+int checkglerrors();
+
+int intcmpf(int *i1, int *i2)
+{
+    if(*i1 < *i2) return -1;
+    if(*i1 > *i2) return 1;
+    return 0;
+}
+
+
+int intcmpfr(int *i1, int *i2)
+{
+    if(*i1 > *i2) return -1;
+    if(*i1 < *i2) return 1;
+    return 0;
+}
+
+struct visibleblockspan
+{
+
+    /// First block of this span
+    int start;
+
+    /// Number of blocks spanned
+    int count;
+
+    /// Block closest to the current player (measured from centre of the block)
+    int nearestblock;
+
+    /// Distance to the nearest block
+    float nearestdist;
+};
+
+vector<int> visibleblocks;
+vector<visibleblockspan> visibleblockspans;
+
+int wdrawcalls = 0;
+
+struct texbatch
+{
+    GLuint vertexbo;
+    GLuint elembo;
+    int elemtype;
+    int tex;
+    int elemcount;
+    vector<int> blockstarts;
+
+    texbatch() : vertexbo(0), elembo(0), tex(0), elemcount(0), elemtype(0) {}
+
+    void deinit()
+    {
+        if(vertexbo) glDeleteBuffers(1, &vertexbo);
+        if(elembo) glDeleteBuffers(1, &elembo);
+        vertexbo = 0;
+        elembo = 0;
+        blockstarts.setsize(0);
+    }
+
+    ~texbatch()
+    {
+        if(vertexbo) glDeleteBuffers(1, &vertexbo);
+        if(elembo) glDeleteBuffers(1, &elembo);
+    }
+
+    void init(int tex)
+    {
+        this->tex = tex;
+        if(!vertexbo) glGenBuffers(1, &vertexbo);
+        if(!elembo) glGenBuffers(1, &elembo);
+    }
+
+    void bind_buffers() const
+    {
+        glBindBuffer(GL_ARRAY_BUFFER, vertexbo);
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, elembo);
+    }
+
+    void pre() const
+    {
+        bind_buffers();
+        glVertexPointer(3, GL_FLOAT, sizeof(vertex), GLBUFOFF(offsetof(vertex, x)));
+        glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(vertex), GLBUFOFF(offsetof(vertex, r)));
+        if(tex)
+        {
+            glTexCoordPointer(2, GL_FLOAT, sizeof(vertex), GLBUFOFF(offsetof(vertex, u)));
+            glBindTexture(GL_TEXTURE_2D, lookupworldtexture(tex)->id);
+        }
+    }
+
+    int blocklen(int i) const
+    {
+        return blockstarts[i+1] - blockstarts[i];
+    }
+
+    int visibleblocklen(int i) const
+    {
+        return blocklen(visibleblocks[i]);
+    }
+
+    int rangelen(int first, int last)
+    {
+        return blockstarts[last] - blockstarts[first];
+    }
+
+    int indexsize() const
+    {
+        return (elemtype == GL_UNSIGNED_INT) ? 4 : 2;
+    }
+
+    void batchdrawold()
+    {
+        int elemsize = (elemtype == GL_UNSIGNED_INT) ? 4 : 2;
+        loopv(visibleblocks)
+        {
+            int block = visibleblocks[i];
+            glDrawElements(GL_TRIANGLES, blocklen(block), elemtype, GLBUFOFF(blockstarts[block]*elemsize));
+            ++wdrawcalls;
+        }
+    }
+
+    void draw() const
+    {
+        glDrawElements(GL_TRIANGLES, elemcount, elemtype, 0);
+    }
+
+// TODO clean up this debug mess
+#ifdef BDDEBUG
+#define BDDEBUGS(v) { v; }
+#else
+#define BDDEBUGS(v) {}
+#endif
+
+    /**
+     * Draw all blocks marked as visible.
+     */
+    void batchdraw()
+    {
+        bool ready = false;
+#ifdef BDDEBUG
+        printf("batchdraw tex:%d ", tex);
+        printf("vblks:%d [", visibleblocks.length());
+        loopv(visibleblocks) printf(" %d", visibleblocks[i]);
+        printf(" ]\n");
+#endif
+        for(int i = 0, vbcount = visibleblocks.length(); i < vbcount; ++i)
+        {
+            int len = 0;
+            int k = i;
+            BDDEBUGS(printf("span start: %d <", k));
+            span:
+            BDDEBUGS(printf(" %d", visibleblocks[k]));
+            len += visibleblocklen(k);
+            while(++k < vbcount && visibleblocks[k-1]+1 == visibleblocks[k])
+            {
+                // Span consecutive visible blocks
+                len += visibleblocklen(k);
+            }
+            BDDEBUGS(printf("..%d", visibleblocks[k-1]));
+            if(k < vbcount)
+            {
+                // If spans of visible blocks are connected by
+                // spans of empty blocks, we can join them together
+                // with no extra cost and save some draw calls.
+                bool joinspans = true;
+                for(int j = visibleblocks[k-1]; j < visibleblocks[k]; ++j)
+                {
+                    if(blocklen(j))
+                    {
+                        joinspans = false;
+                        break;
+                    }
+                }
+                if(joinspans)
+                {
+                    goto span;
+                }
+            }
+            BDDEBUGS(printf(" > span end: %d\n", k-1));
+            if(len)
+            {
+                if(!ready)
+                {
+                    // Only perform state changes for this texture when
+                    // something visible actually needs to be rendered.
+                    pre();
+                    ready = true;
+                }
+                if(elemcount < 500)
+                {
+                    // Don't bother with occlusion if this batch only has
+                    // a few verts. Render them all in one go.
+                    draw();
+                    return;
+                }
+                glDrawElements(GL_TRIANGLES, len, elemtype, GLBUFOFF(blockstarts[visibleblocks[i]]*indexsize()));
+                ++wdrawcalls;
+            }
+            i = k-1;
+        }
+    }
+
+};
+
+struct coord2d
+{
+    int x, y;
+    //coord2d(int x=0, int y=0) : x(x), y(y) {}
+};
+
+enum { TOP = 0, RIGHT, BOTTOM, LEFT, NUM_SIDES };
+const coord2d NEIGHBOUR_OFFSETS[] = { {0, -1}, {1, 0}, {0, 1}, {-1, 0} };
+
+
+
+int opposingside(int side)
+{
+    switch(side)
+    {
+        case TOP: return BOTTOM;
+        case RIGHT: return LEFT;
+        case BOTTOM: return TOP;
+        case LEFT: return RIGHT;
+    }
+    return -1;
+}
+
+int modulo(int a, int b)
+{
+    while(a < 0) a += b;
+    return a % b;
+}
+
+/**
+ * @brief Return the next side in the given direction.
+ *
+ * Clockwise by default.
+ */
+int nextside(int side, bool ccw=false)
+{
+    return modulo(side + (ccw?-1:1), NUM_SIDES);
+}
+
+enum { TOP_LEFT = 0, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT, NUM_CORNERS };
+const coord2d CORNER_OFFSETS[] = { {0, 0}, {1, 0}, {0, 1}, {1, 1} };
+
+void corner_offsets(int c, int &x, int &y)
+{
+    x = c&1;
+    y = (c&2) >> 1;
+}
+
+/**
+ * @brief Get the two corners that hug the given side.
+ */
+void sidecorners(int side, int *corners, bool flip=false)
+{
+    switch(side)
+    {
+    case TOP:
+        corners[0] = TOP_RIGHT;
+        corners[1] = TOP_LEFT;
+        break;
+    case RIGHT:
+        corners[0] = BOTTOM_RIGHT;
+        corners[1] = TOP_RIGHT;
+        break;
+    case BOTTOM:
+        corners[0] = BOTTOM_LEFT;
+        corners[1] = BOTTOM_RIGHT;
+        break;
+    case LEFT:
+        corners[0] = TOP_LEFT;
+        corners[1] = BOTTOM_LEFT;
+    }
+    if(flip)
+    {
+        swap(corners[0], corners[1]);
+    }
+}
+
+// Set x and y to the corner offsets from the topleft corner of the cube
+#define COFFSET(c, x, y) { x = (c)&1; y = ((c)&2) >> 1; }
+
+// Check if corner is along the Left, Right, Top, Bottom edges.
+#define CL(c) ((c)&1 == 0)
+#define CR(c) ((c)&1 == 1)
+#define CT(c) ((c)&2 == 0)
+#define CB(c) ((c)&2 == 2)
+
+/// Check if the two corners form a diagonal
+#define CDIAG(c1, c2) ((CL(c1) != CL(c2)) && (CT(c1) != CT(c2)))
+
+/**
+ * @brief Get the cube adjacent to the cube at (x,y) along the given side.
+ */
+sqr *adjcube(int x, int y, int side, int stride=1)
+{
+    coord2d o = NEIGHBOUR_OFFSETS[side];
+    return S(x + stride*o.x, y + stride*o.y);
+}
+
+/**
+ * @brief Get the corner that joints the two sides.
+ *
+ * @returns the corner common to the given sides, or -1 if non-neighbouring
+ */
+int commoncorner(int side1, int side2)
+{
+    int side1corners[2], side2corners[2];
+    sidecorners(side1, side1corners);
+    sidecorners(side2, side2corners);
+    loopi(2) loopk(2) if(side1corners[i] == side2corners[k]) return side1corners[i];
+    return -1;
+}
+
+/**
+ * @brief Find the vdeltas for the cube at (x, y).
+ *
+ * Returns 0 if the given surface (floor/ceil) is not a heightfield.
+ *
+ * (xo,yo) are corners, (0,0) for topleft, (1,1) for bottomright.
+ *
+ */
+int cornervdelta(int x, int y, int xo, int yo, bool ceil)
+{
+    int type = S(x,y)->type;
+    int vdelta = S(x+xo,y+yo)->vdelta;
+    switch(type)
+    {
+        case FHF: return !ceil ? -vdelta : 0;
+        case CHF: return ceil ? vdelta : 0;
+        default: return 0;
+    }
+}
+
+int cornervdelta(int x, int y, int corner, bool ceil)
+{
+    coord2d o = CORNER_OFFSETS[corner];
+    return cornervdelta(x, y, o.x, o.y, ceil);
+}
+
+int cornerheight(int x, int y, int xo, int yo, bool ceil)
+{
+    sqr const *s = S(x,y);
+    return 4*(ceil ? s->ceil : s->floor) + cornervdelta(x, y, xo, yo, ceil);
+}
+
+int cornerheight(int x, int y, int corner, bool ceil)
+{
+    coord2d o = CORNER_OFFSETS[corner];
+    return cornerheight(x, y, o.x, o.y, ceil);
+}
+
+/**
+ * @brief Check if cubes at (x1,y1) and (x2, y2) share an edge.
+ */
+bool sideisshared(int x1, int y1, int x2, int y2)
+{
+    int xd = x1-x2;
+    int yd = y1-y2;
+    // TODO This looks like a place where something needs to be done.
+    return true;
+}
+
+// The order in which floor/corner vertices are to be drawn for a triangle pair
+const int FCORNERX[] = { 0, 1, 0, 1, 1, 0 };
+const int FCORNERY[] = { 0, 0, 1, 0, 1, 1 };
+const int CCORNERX[] = { 0, 0, 1, 0, 1, 1 };
+const int CCORNERY[] = { 0, 1, 0, 1, 1, 0 };
+
+typedef unsigned int arrayindex;
+
+/**
+ * Helper class for constructing the world mesh.
+ *
+ * Not used for actual rendering, but generating the VBOs.
+ */
+struct worldmesh
+{
+
+    hashtable<vertexpoint, int> elemindexmap[256];
+    vector<vertex> verts[256];
+    vector<arrayindex> vertindices[256];
+
+    int vertex_index(int x, int y, int h, int tex, int xo, int yo, int wall=FLAT)
+    {
+        int ax = x + xo, ay = y + yo;
+        vertexpoint vp(ax, ay, h, wall);
+        int *idx = elemindexmap[tex].access(vp);
+        if(idx) return *idx;
+        vector<vertex> *vs = verts + tex;
+        int newidx = vs->length();
+
+        Texture const *texture = lookupworldtexture(tex);
+        float texscale = 32.0f * ((uniformtexres && texture->scale>1.0f) ? 1.0f : texture->scale);
+        float xs = texscale / texture->xs;
+        float ys = texscale / texture->ys;
+
+        vertex v;
+        v.x = ax;
+        v.y = ay;
+        v.z = h * 0.25f;
+        if(wall)
+        {
+            v.u = (wall == WALL_LEFTTORIGHT ? ay : ax) * xs;
+            v.v = -v.z * ys;
+        }
+        else
+        {
+            v.u = xs * ax;
+            v.v = ys * ay;
+        }
+        VERTCOLOURS(v, *S(ax, ay));
+
+        vs->add(v);
+        return elemindexmap[tex].access(vp, newidx);
+    }
+
+    bool hasdata() const
+    {
+        loopi(256) if(verts[i].length()) return true;
+        return false;
+    }
+
+    void addvert(int x, int y, int h, int tex, int xo, int yo, int wall=FLAT)
+    {
+        vertindices[tex].add(vertex_index(x, y, h, tex, xo, yo, wall));
+    }
+
+    /**
+     * @brief Add a wall face.
+     *
+     * x,y coordinates of the cube this wall belongs to
+     * bh1, bh2 bottom height (elevation) of the bottom of the wall
+     * uh1, uh2 upper height of the top of the wall
+     * corner1, corner2 corners this wall spans
+     * tex texture id
+     */
+    void wallquad(int x, int y, int bh1, int bh2, int uh1, int uh2, int corner1, int corner2, int tex)
+    {
+
+        int xo1, yo1, xo2, yo2;
+        corner_offsets(corner1, xo1, yo1);
+        corner_offsets(corner2, xo2, yo2);
+
+        int wall = WALL_LEFTTORIGHT;
+        if(xo1 != xo2) wall = WALL_TOPTOBOTTOM;
+
+        addvert(x+xo1, y+yo1, uh1, tex, 0, 0, wall);
+        addvert(x+xo2, y+yo2, uh2, tex, 0, 0, wall);
+        addvert(x+xo1, y+yo1, bh1, tex, 0, 0, wall);
+        addvert(x+xo1, y+yo1, bh1, tex, 0, 0, wall);
+        addvert(x+xo2, y+yo2, uh2, tex, 0, 0, wall);
+        addvert(x+xo2, y+yo2, bh2, tex, 0, 0, wall);
+
+    }
+
+    void cubewalls(int x, int y, bool ceil)
+    {
+        sqr const *s = S(x, y), *o;
+        //if(s->type == CORNER) return;
+        if(ceil && SOLID(s)) return;
+
+        int ch1, ch2; // Heights of first and second corners
+
+        int corners[2];
+        // TODO try to get rid of duplicated code in wall/floor sections
+        if(!ceil)
+        {
+            loopi(NUM_SIDES)
+            {
+                sidecorners(i, corners);
+                coord2d no = NEIGHBOUR_OFFSETS[i];
+                int xo = x + no.x;
+                int yo = y + no.y;
+                if(OUTBORD(xo, yo)) continue;
+                o = S(xo, yo);
+                if(SOLID(o)) continue;
+                int ch1, ch2;
+                ch1 = ch2 = 4*s->floor;
+                if(!SOLID(s)) {
+                    ch1 = cornerheight(x, y, corners[0], ceil);
+                    ch2 = cornerheight(x, y, corners[1], ceil);
+                }
+                else
+                {
+                    for(int yo = -1; yo <= 1; ++yo) for(int xo = -1; xo <= 1; ++xo)
+                    {
+                        if(SOLID(S(x+xo, y+yo))) continue;
+                        loopk(NUM_CORNERS) ch1 = ch2 = max(ch1, cornerheight(x+xo, y+yo, k, true));
+                    }
+                }
+                int lowheight = 4*min<int>(s->floor, o->floor);
+                if(s->type == FHF || o->type == FHF)
+                {
+                    for(int yo = -1; yo <= 1; ++yo) for(int xo = -1; xo <= 1; ++xo)
+                    {
+                        loopk(NUM_CORNERS) lowheight = min(lowheight, cornerheight(x+xo, y+yo, k, ceil));
+                    }
+                }
+
+                {
+                    // If the adjacent corners of this and the adjacent cube
+                    // are at the same height, then there is obviously no wall
+                    // between them.
+                    int adjcorners[2];
+                    sidecorners(opposingside(i), adjcorners, true);
+                    if(ch1 == cornerheight(xo, yo, adjcorners[0], ceil)
+                        && ch2 == cornerheight(xo, yo, adjcorners[1], ceil))
+                    {
+                        continue;
+                    }
+                }
+                if((ch1 > lowheight || ch2 > lowheight))
+                    wallquad(x, y, lowheight, lowheight, ch1, ch2, corners[0], corners[1], s->wtex);
+            }
+        }
+        else
+        {
+            loopi(NUM_SIDES)
+            {
+                sidecorners(i, corners);
+                coord2d no = NEIGHBOUR_OFFSETS[i];
+                int xo = x + no.x;
+                int yo = y + no.y;
+                o = S(xo, yo);
+                if(SOLID(o)) continue;
+                ch1 = cornerheight(x, y, corners[0], ceil);
+                ch2 = cornerheight(x, y, corners[1], ceil);
+                int highheight = 4*max(s->ceil, o->ceil);
+                if(s->type == CHF || o->type == CHF)
+                {
+                    for(int yo = -1; yo <= 1; ++yo) for(int xo = -1; xo <= 1; ++xo)
+                    {
+                        if(SOLID(S(x+xo, y+yo))) continue;
+                        loopk(NUM_CORNERS)
+                        {
+                            highheight = max(highheight, cornerheight(x+xo, y+yo, k, ceil));
+                        }
+                    }
+                }
+                {
+                    // If the adjacent corners of this and the adjacent cube
+                    // are at the same height, then there is obviously no wall
+                    // between them.
+                    int adjcorners[2];
+                    sidecorners(opposingside(i), adjcorners, true);
+                    if(ch1 == cornerheight(xo, yo, adjcorners[0], ceil)
+                        && ch2 == cornerheight(xo, yo, adjcorners[1], ceil))
+                    {
+                        continue;
+                    }
+                }
+                if((ch1 < highheight || ch2 < highheight))
+                    wallquad(x, y, ch1, ch2, highheight, highheight, corners[0], corners[1], s->utex);
+            }
+
+        }
+
+
+    }
+
+    void flat(int x, int y, bool ceil, int size=1)
+    {
+        sqr const *s = S(x, y);
+        if(SOLID(s)) return;
+        int tex = ceil ? s->ctex : s->ftex;
+
+        int h = ceil ? s->ceil : s->floor;
+        h *= 4;
+
+        const int *cxs = FCORNERX;
+        const int *cys = FCORNERY;
+        if(ceil)
+        {
+            cxs = CCORNERX;
+            cys = CCORNERY;
+        }
+        loopi(6) // 6 verts per flat face (2 triangles to make a quad)
+        {
+            int cx = cxs[i];
+            int cy = cys[i];
+            int xoff = cx * (size-1);
+            int yoff = cy * (size-1);
+            addvert(x+xoff, y+yoff, h + cornervdelta(x+xoff, y+yoff, cx, cy, ceil), tex, cx, cy);
+            //addvert(x, y, h + cornervdelta(x, y, cx, cy, ceil), tex, cx*size, cy*size);
+        }
+    }
+
+    vector<int> startindices[256];
+
+    /**
+     * @brief Mark the beginning of each render block.
+     */
+    void mark()
+    {
+        loopi(256)
+        {
+            startindices[i].add(vertindices[i].length());
+        }
+    }
+
+    /**
+     * @brief Shove world geometry to the GPU.
+     */
+    void loadtogpu(texbatch &b)
+    {
+        checkglerrors();
+        b.bind_buffers();
+        vector<vertex> *vs = verts + b.tex;
+        glBufferData(GL_ARRAY_BUFFER, sizeof(vertex) * vs->length(), vs->getbuf(), GL_STATIC_DRAW);
+        vector<arrayindex> *evec = vertindices + b.tex;
+        b.elemcount = evec->length();
+        startindices[b.tex].add(b.elemcount);
+        b.blockstarts = startindices[b.tex];
+        if(b.elemcount <= 65535)
+        {
+            b.elemtype = GL_UNSIGNED_SHORT;
+            ushort *shorts = new ushort[b.elemcount];
+            loopi(b.elemcount) shorts[i] = (*evec)[i];
+            glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(ushort) * b.elemcount, shorts, GL_STATIC_DRAW);
+            delete[] shorts;
+        }
+        else
+        {
+            b.elemtype = GL_UNSIGNED_INT;
+            glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(uint) * b.elemcount, evec->getbuf(), GL_STATIC_DRAW);
+        }
+        DEBUG("updated buffer data for texture " << b.tex << ": "
+            << vs->length() << " verts, "
+            << b.elemcount << " indices (" << ((b.elemtype == GL_UNSIGNED_INT) ? "uint" : "ushort") << ")");
+    }
+
+    void loadtogpu(texbatch *b, int n=1)
+    {
+        int startmillis = SDL_GetTicks();
+        loopi(n) loadtogpu(b[i]);
+        int endmillis = SDL_GetTicks();
+        DEBUG("Updated all world geometry buffer objects, time taken: "
+            << endmillis - startmillis
+            << "ms\n");
+    }
+
+};
+
+texbatch texbatches[256];
+
+#define wloop(i) for(int i = 1, end = ssize - 1; i < end; ++i)
+#define wbloop(start, end, var) for(int var = max(1, static_cast<int>(start)), __end = max(ssize-1, static_cast<int>(end)); var < __end; ++var)
+
+// Map geometry has been updated and static geometry on the GPU needs updating.
+bool regenworldbuffers = true;
+
+/**
+ * @brief Update GPU-side world geometry before next frame is rendered.
+ */
+void postregenworldvbos()
+{
+    if(!usenewworldrenderer)
+    {
+        // This doesn't belong here either.
+        loopi(256) texbatches[i].deinit();
+    }
+    visibleblocks.setsize(0);
+    resetwater(); // RESETWATER DOESN'T EVEN GO HERE. I think this is now done... somewhere else. prepgpudata?
+    regenworldbuffers = true;
+}
+
+
+int checkglerrors()
+{
+    int errcount = 0;
+    GLenum error;
+    while((error = glGetError()) != GL_NO_ERROR)
+    {
+        ++errcount;
+        const char *str = "unknown";
+        switch(error)
+        {
+        case GL_NO_ERROR: str = "No error"; break;
+        case GL_INVALID_ENUM: str = "Invalid enum"; break;
+        case GL_INVALID_VALUE: str = "Invalid value"; break;
+        case GL_INVALID_OPERATION: str = "Invalid operation"; break;
+        case GL_STACK_OVERFLOW: str = "Stack overflow"; break;
+
+        }
+        printf("OpenGL error: %s\n", str);
+    }
+    return errcount;
+}
+
+extern void recalc();
+void checkbssize();
+VARFP(bssize, 2, 32, 128, checkbssize(); postregenworldvbos());
+
+/**
+ * @brief Make sure bssize is a power of two.
+ */
+void checkbssize()
+{
+    int m = 1 << 16;
+    while((m&bssize) == 0) m >>= 1;
+    if(m != bssize)
+    {
+        conoutf("bssize must be a power of two, using %d", m);
+    }
+    bssize = m;
+}
+
+
+#define bloopxy(xb, yb) wbloop(yb*bssize, (yb+1)*bssize, y) wbloop(xb*bssize, (xb+1)*bssize, x)
+
+/**
+ * @brief Do you even flat bro?
+ */
+bool isevenflat(sqr const *s, bool ceil)
+{
+    return (s->type == SPACE) || (s->type == (ceil ? FHF : CHF));
+}
+
+/**
+ * @brief Check if two cubes are identical enough to be merged into a mip.
+ *
+ * If a given set of power-of-two aligned cubes are all unifiable,
+ * they can be rendered as one cube is basically what this means. Basically.
+ */
+bool unifiable(sqr const *s1, sqr const *s2, bool ceil)
+{
+    //if((s1->type == CORNER) != (s2->type == CORNER)) return false;
+    if(s1->type == CORNER && s2->type == CORNER) return true;
+    if(!isevenflat(s1, ceil) || !isevenflat(s2, ceil)) return false;
+    if(ceil)
+    {
+        if(s1->ctex != s2->ctex) return false;
+        if(s1->ceil != s2->ceil) return false;
+    }
+    else
+    {
+        if(s1->ftex != s2->ftex) return false;
+        if(s1->floor != s2->floor) return false;
+    }
+    return true;
+}
+
+/**
+ * @brief What is this?
+ */
+void meshqt(worldmesh *wm, int x1, int y1, int bsize)
+{
+
+}
+
+/**
+ * @brief Generate walls for corner cubes.
+ */
+void cornerwalls(worldmesh *wm, int x1, int y1, int bsize)
+{
+    // TODO finish me.
+    if(bsize == 0) return;
+    for(int y = y1, yend = y1+bsize; y < yend; ++y)
+    {
+        for(int x = x1, xend = x1+bsize; x < xend; ++x)
+        {
+            if(S(x, y)->type != CORNER)
+            {
+                int hbsize = bsize / 2;
+                cornerwalls(wm, x1,        y1,        hbsize);
+                cornerwalls(wm, x1+hbsize, y1,        hbsize);
+                cornerwalls(wm, x1,        y1+hbsize, hbsize);
+                cornerwalls(wm, x1+hbsize, y1+hbsize, hbsize);
+                return;
+            }
+        }
+    }
+    // No corners that hug the very edges of the map. Sorry.
+    if(x1 == 0 || y1 == 0 || x1+bsize >= ssize || y1+bsize == ssize) return;
+    sqr const *s = S(x1, y1);
+    loopi(NUM_SIDES)
+    {
+        if(adjcube(x1, y1, i, bsize)->type == SOLID
+            && adjcube(x1, y1, nextside(i), bsize)->type == SOLID)
+        {
+
+        }
+    }
+
+}
+
+/**
+ * @brief Generate floor and ceiling geometry quadtree style.
+ *
+ * QUADTREE STYLE!
+ *
+ * Takes into account lighterror but current lighterror code is a bit..
+ * primitive.
+ */
+void flatmeshqt(worldmesh *wm, int x1, int y1, int bsize, bool ceil)
+{
+
+    int xbeg = max(1, x1);
+    int ybeg = max(1, y1);
+    int xend = min(ssize-1, x1+bsize);
+    int yend = min(ssize-1, y1+bsize);
+
+    sqr const *prev = S(xbeg, ybeg);
+    bool hf = (ceil && prev->type == CHF) || (!ceil && prev->type == FHF);
+
+    int lighterr = 0;
+    extern int lighterror;
+    int maxlighterr = lighterror * lighterror;
+    if(bsize == 1) goto end;
+    for(int y = ybeg; y < yend; ++y)
+    {
+        for(int x = xbeg; x < xend; ++x)
+        {
+            sqr const *s = S(x, y);
+            lighterr += abs(s->r - prev->r) + abs(s->g - prev->g) + abs(s->b - prev->b);
+            if(!unifiable(prev, s, ceil) || (lighterr > maxlighterr))
+            {
+                int hbsize = bsize / 2;
+                flatmeshqt(wm, x1,        y1,        hbsize, ceil);
+                flatmeshqt(wm, x1+hbsize, y1,        hbsize, ceil);
+                flatmeshqt(wm, x1+hbsize, y1+hbsize, hbsize, ceil);
+                flatmeshqt(wm, x1,        y1+hbsize, hbsize, ceil);
+                return;
+            }
+        }
+    }
+    end:
+    /*if(prev->type != CORNER)*/ wm->flat(x1, y1, ceil, bsize);
+    if(!SOLID(prev) && waterlevel > prev->floor) addwaterquad(x1, y1, bssize);
+}
+
+bool iswatercube(sqr const *s)
+{
+    return !SOLID(s) && (waterlevel >= s->floor);
+}
+
+/**
+ * @brief Find visible water quads in the given area.
+ */
+void findwaterquadsqt(int x, int y, int size, int minsize)
+{
+    bool iswaterquad = iswatercube(S(x, y));
+    loopi(size) loopk(size)
+    {
+        sqr const *s = S(x+k, y+i);
+        if(iswatercube(s) != iswaterquad)
+        {
+            if(size <= minsize)
+            {
+                iswaterquad = true;
+                goto done;
+            }
+            int hsize = size / 2;
+            findwaterquadsqt(x,       y,       hsize, minsize);
+            findwaterquadsqt(x+hsize, y,       hsize, minsize);
+            findwaterquadsqt(x,       y+hsize, hsize, minsize);
+            findwaterquadsqt(x+hsize, y+hsize, hsize, minsize);
+            return;
+        }
+    }
+    done:
+    if(iswaterquad && !isoccluded(camera1->o.x, camera1->o.y, x, y, size))
+    {
+        addwaterquad(x, y, size);
+    }
+}
+
+/**
+ * @brief Find all visible water quads.
+ */
+void findwaterquads()
+{
+	// FIXME this function is an unacceptable fps drainer, optimise or
+	// come up with a better way of dealing with water quads.
+    findwaterquadsqt(0, 0, ssize, 4);
+}
+
+#define BI(x,y) (y*(ssize/bssize)+x)
+#define BX(i) (i/bssize)
+#define BY(i) (i%bssize)
+
+
+int getbscount()
+{
+    return ssize / bssize;
+}
+
+/**
+ * @brief Get the (x,y) coordinates of the centre of the given block
+ */
+coord2d blockpos(int b)
+{
+    int bscount = getbscount();
+    coord2d bpos;
+    int hbssize = bssize / 2;
+    bpos.x = (b % bscount) + hbssize;
+    bpos.y = (b / bscount) + hbssize;
+    return bpos;
+}
+
+void findvisibleblocks()
+{
+    visibleblocks.setsize(0);
+    int bscount = ssize / bssize;
+
+    loopj(bscount) loopk(bscount)
+    {
+        //if(!isoccluded(camera1->o.x, camera1->o.y, j*bssize+bssize/2, k*bssize+bssize/2, bssize/2))
+        if(!isoccluded(camera1->o.x, camera1->o.y, k*bssize, j*bssize, bssize))
+        {
+            visibleblocks.add(BI(k, j));
+        }
+    }
+
+
+
+    /*
+    findvisiblecubes();
+    loopi(ssize) loopk(ssize)
+    {
+        if(!S(k, i)->occluded)
+        {
+            int b = BI(k/bssize, i/bssize);
+            bool in = false;
+            loopv(visibleblocks) if(b == visibleblocks[i]) { in = true; break; }
+            if(!in)
+            {
+                //printf("added %d\n", b);
+                visibleblocks.add(b);
+            }
+        }
+    }
+    */
+
+    visibleblocks.sort<int>(intcmpf);
+
+    visibleblockspans.setsize(0);
+    if(visibleblocks.length() == 0) return;
+
+    visibleblockspan *span = &(visibleblockspans.add());
+    span->start = visibleblocks[0];
+    span->count = 1;
+    for(int i = 1; i < visibleblocks.length(); ++i)
+    {
+        if((visibleblocks[i-1]+1 == visibleblocks[i]))
+        {
+            ++span->count;
+        }
+        else
+        {
+            span = &(visibleblockspans.add());
+            span->count = 1;
+        }
+    }
+}
+
+
+void prepgpudata()
+{
+    if(!regenworldbuffers) return;
+
+    // TODO separate world buffer generation and renderer initialisation
+    if(!loadglprocs())
+    {
+        conoutf("Failed to load OpenGL entry points required for new world renderer");
+        usenewworldrenderer = 0;
+        return;
+    }
+    loopi(256) texbatches[i].init(i);
+    worldmesh wm;
+    wm.mark();
+    int bscount = ssize / bssize;
+    loopi(bscount) loopk(bscount)
+    {
+        flatmeshqt(&wm, k*bssize, i*bssize, bssize, false);
+        flatmeshqt(&wm, k*bssize, i*bssize, bssize, true);
+        loop(y, bssize) loop(x, bssize) wm.cubewalls(k*bssize+x, i*bssize+y, false);
+        loop(y, bssize) loop(x, bssize) wm.cubewalls(k*bssize+x, i*bssize+y, true);
+        wm.mark();
+    }
+    wm.loadtogpu(texbatches, 256);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+    regenworldbuffers = false;
+}
+
+void rendertrissky()
+{
+    if(texbatches[0].elemcount)
+    {
+        skyfloor = -128.0f; // No idea what this does
+        glDisable(GL_TEXTURE_2D);
+        glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+        glEnableClientState(GL_VERTEX_ARRAY);
+        glEnableClientState(GL_ARRAY_BUFFER);
+        glEnableClientState(GL_COLOR_ARRAY);
+        texbatches[0].pre();
+        glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+        texbatches[0].batchdraw();
+        glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+        glEnable(GL_TEXTURE_2D);
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+    }
+}
+
+// TODO git rid of unused arguments
+void render_world_new(float vx, float vy, float vh, float changelod, int yaw, int pitch, float fov, float fovy, int w, int h)
+{
+    wdrawcalls = 0;
+
+    if(!visibleblocks.length()) goto done;
+
+    glEnable(GL_TEXTURE_2D);
+    glEnableClientState(GL_ARRAY_BUFFER);
+    glEnableClientState(GL_VERTEX_ARRAY);
+    glEnableClientState(GL_COLOR_ARRAY);
+    glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+    for(int i = 1; i < 256; ++i)
+    {
+        if(texbatches[i].elemcount == 0) continue;
+        texbatches[i].batchdraw();
+    }
+
+    done:
+    // Is this really necessary?
+    glDisableClientState(GL_ARRAY_BUFFER);
+    glDisableClientState(GL_COLOR_ARRAY);
+    glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+
+    // This is really necessary.
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+}
+
+#undef VERTCOLOURS

--- a/source/src/newworldrender.cpp
+++ b/source/src/newworldrender.cpp
@@ -1135,6 +1135,8 @@ double blockdist(int b)
     return sqrt(pow(bp.x-camera1->o.x, 2) + pow(bp.y-camera1->o.y, 2));
 }
 
+VARP(maxrenderblockspanlength, 1, 1000, 100000);
+
 /**
  * @brief Find all visible (non-occluded) render blocks.
  *
@@ -1163,7 +1165,7 @@ void findvisibleblocks()
     for(int i = 1; i < visibleblocks.length(); ++i)
     {
         int vb = visibleblocks[i];
-        if((visibleblocks[i-1]+1 == vb))
+        if(visibleblocks[i-1]+1 == vb && span->count < maxrenderblockspanlength)
         {
             ++span->count;
             span->updatenearest(vb);

--- a/source/src/newworldrender.cpp
+++ b/source/src/newworldrender.cpp
@@ -200,7 +200,7 @@ public:
     {
         this->tex = tex;
         if(!vertexbo || !glIsBuffer(vertexbo)) glGenBuffers(1, &vertexbo);
-        if(!elembo || !glIsBuffer(vertexbo)) glGenBuffers(1, &elembo);
+        if(!elembo || !glIsBuffer(elembo)) glGenBuffers(1, &elembo);
     }
 
     void bind_buffers() const
@@ -746,15 +746,22 @@ int regenworldbuffers = RWB_HARD;
  */
 void postregenworldvbos(bool hard)
 {
-    if(!usenewworldrenderer)
-    {
-        // Should this go somewhere else?
-        loopi(256) texbatches[i].deinit();
-    }
     visibleblocks.setsize(0);
     regenworldbuffers = max<int>(regenworldbuffers, hard ? RWB_HARD : RWB_SOFT);
 }
 
+/**
+ * nwr geometry data is kept on the GPU to make toggling
+ * faster. If it's necessary to evict all of it, use this.
+ */
+void unloadnewworldrenderer()
+{
+    loopi(256) texbatches[i].deinit();
+    usenewworldrenderer = 0;
+    postregenworldvbos(true);
+}
+
+COMMAND(unloadnewworldrenderer, "");
 
 int checkglerrors()
 {

--- a/source/src/newworldrender.cpp
+++ b/source/src/newworldrender.cpp
@@ -738,9 +738,9 @@ struct worldmesh
 
     void loadtogpu(texbatch *b, int n=1)
     {
-        DEBUGS(int startmillis = SDL_GetTicks());
+        DEBUGCODE(int startmillis = SDL_GetTicks());
         loopi(n) loadtogpu(b[i]);
-        DEBUGS(int endmillis = SDL_GetTicks());
+        DEBUGCODE(int endmillis = SDL_GetTicks());
         DEBUG("Updated all world geometry buffer objects, time taken: "
             << endmillis - startmillis
             << "ms\n");
@@ -1201,7 +1201,7 @@ void prepgpudata()
         return;
     }
     loopi(256) texbatches[i].init(i);
-    DEBUGS(Uint32 startmillis = SDL_GetTicks());
+    DEBUGCODE(Uint32 startmillis = SDL_GetTicks());
     worldmesh wm;
     wm.mark();
     int bscount = ssize / bssize;
@@ -1216,7 +1216,7 @@ void prepgpudata()
         cornertris(&wm, k*bssize, i*bssize, bssize);
         wm.mark();
     }
-    DEBUGS(Uint32 millis = SDL_GetTicks() - startmillis);
+    DEBUGCODE(Uint32 millis = SDL_GetTicks() - startmillis);
     DEBUG("generated world geometry in " << millis << "ms");
     wm.loadtogpu(texbatches, 256);
     glBindBuffer(GL_ARRAY_BUFFER, 0);

--- a/source/src/platform.h
+++ b/source/src/platform.h
@@ -44,7 +44,7 @@
 
     #define GL_GLEXT_LEGACY
     #define __glext_h__
-    #define NO_SDL_GLEXT
+    //#define NO_SDL_GLEXT
     #include <SDL_opengl.h>
     #undef __glext_h__
 

--- a/source/src/protos.h
+++ b/source/src/protos.h
@@ -667,7 +667,7 @@ extern void computeraytable(float vx, float vy, float fov);
 extern int isoccluded(float vx, float vy, float cx, float cy, float csize);
 
 // new worldrenderer
-extern void postregenworldvbos();
+extern void postregenworldvbos(bool hard=false);
 
 // main
 extern char *lang;
@@ -730,11 +730,14 @@ extern void text_endcolumns();
 extern void cutcolorstring(char *text, int len);
 extern bool filterunrenderables(char *s);
 
+extern int usenewworldrenderer;
+extern void postregenworldvbos(bool);
+
 // editing
-#define EDITSEL(x)   if(noteditmode(x) || noselection()) return
-#define EDITSELMP(x) if(noteditmode(x) || noselection() || multiplayer(x)) return
-#define EDITMP(x)    if(noteditmode(x) || multiplayer(x)) return
-#define EDIT(x)      if(noteditmode(x)) return
+#define EDITSEL(x)   if(noteditmode(x) || noselection()) return; if(usenewworldrenderer) postregenworldvbos()
+#define EDITSELMP(x) if(noteditmode(x) || noselection() || multiplayer(x)) return; if(usenewworldrenderer) postregenworldvbos()
+#define EDITMP(x)    if(noteditmode(x) || multiplayer(x)) return; if(usenewworldrenderer) postregenworldvbos()
+#define EDIT(x)      if(noteditmode(x)) return; if(usenewworldrenderer && strcmp(x, "editentity")) postregenworldvbos()
 extern void cursorupdate();
 extern void toggleedit(bool force = false);
 extern void reseteditor();

--- a/source/src/protos.h
+++ b/source/src/protos.h
@@ -666,6 +666,9 @@ extern void disableraytable();
 extern void computeraytable(float vx, float vy, float fov);
 extern int isoccluded(float vx, float vy, float cx, float cy, float csize);
 
+// new worldrenderer
+extern void postregenworldvbos();
+
 // main
 extern char *lang;
 extern SDL_Surface *screen;

--- a/source/src/rendergl.cpp
+++ b/source/src/rendergl.cpp
@@ -25,6 +25,12 @@ PFNGLACTIVESTENCILFACEEXTPROC glActiveStencilFace_ = NULL;
 PFNGLSTENCILOPSEPARATEATIPROC   glStencilOpSeparate_ = NULL;
 PFNGLSTENCILFUNCSEPARATEATIPROC glStencilFuncSeparate_ = NULL;
 
+extern int usenewworldrenderer;
+extern void findvisibleblocks();
+extern void findwaterquads();
+extern void rendertrissky();
+extern void render_world_new(float vx, float vy, float vh, float changelod, int yaw, int pitch, float fov, float fovy, int w, int h);
+
 void *getprocaddress(const char *name)
 {
     return SDL_GL_GetProcAddress(name);
@@ -675,12 +681,15 @@ void drawreflection(float hf, int w, int h, float changelod, bool refract)
         glEnable(GL_SCISSOR_TEST);
     }
 
-    resetcubes();
+    if(!usenewworldrenderer)
+    {
+        resetcubes();
 
-    render_world(camera1->o.x, camera1->o.y, refract ? camera1->o.z : hf, changelod,
-            (int)camera1->yaw, (refract ? 1 : -1)*(int)camera1->pitch, dynfov(), fovy, size, size);
+        render_world(camera1->o.x, camera1->o.y, refract ? camera1->o.z : hf, changelod,
+                (int)camera1->yaw, (refract ? 1 : -1)*(int)camera1->pitch, dynfov(), fovy, size, size);
 
-    setupstrips();
+        setupstrips();
+    }
 
     if(!refract) glCullFace(GL_BACK);
     glViewport(0, 0, size, size);
@@ -701,7 +710,14 @@ void drawreflection(float hf, int w, int h, float changelod, bool refract)
     glLoadMatrixf(clipmatrix.v);
     glMatrixMode(GL_MODELVIEW);
 
-    renderstripssky();
+    if(usenewworldrenderer)
+    {
+        rendertrissky();
+    }
+    else
+    {
+        renderstripssky();
+    }
 
     glPushMatrix();
     glLoadIdentity();
@@ -720,7 +736,15 @@ void drawreflection(float hf, int w, int h, float changelod, bool refract)
 
     setuptmu(0, "T * P x 2");
 
-    renderstrips();
+    if(usenewworldrenderer)
+    {
+        render_world_new(camera1->o.x, camera1->o.y, camera1->o.z, changelod,
+                (int)camera1->yaw, (int)camera1->pitch, dynfov(), fovy, w, h);
+    }
+    else
+    {
+        renderstrips();
+    }
     rendermapmodels();
     renderentities();
     renderclients();
@@ -1094,15 +1118,9 @@ void gl_drawframe(int w, int h, float changelod, float curfps, int elapsed)
 
     if(usenewworldrenderer)
     {
-
-        extern void findvisibleblocks();
-        extern void findwaterquads();
-        extern void rendertrissky();
-
         findvisibleblocks();
         findwaterquads();
         rendertrissky();
-
     }
     else
     {
@@ -1133,7 +1151,6 @@ void gl_drawframe(int w, int h, float changelod, float curfps, int elapsed)
 
     if(usenewworldrenderer)
     {
-        extern void render_world_new(float vx, float vy, float vh, float changelod, int yaw, int pitch, float fov, float fovy, int w, int h);
         render_world_new(camera1->o.x, camera1->o.y, camera1->o.z, changelod,
                 (int)camera1->yaw, (int)camera1->pitch, dynfov(), fovy, w, h);
 

--- a/source/src/rendergl.cpp
+++ b/source/src/rendergl.cpp
@@ -29,7 +29,7 @@ extern int usenewworldrenderer;
 extern void findvisibleblocks();
 extern void findwaterquads();
 extern void rendertrissky();
-extern void render_world_new(float vx, float vy, float vh, float changelod, int yaw, int pitch, float fov, float fovy, int w, int h);
+extern void render_world_new();
 
 void *getprocaddress(const char *name)
 {
@@ -740,8 +740,7 @@ void drawreflection(float hf, int w, int h, float changelod, bool refract)
 
     if(usenewworldrenderer)
     {
-        render_world_new(camera1->o.x, camera1->o.y, camera1->o.z, changelod,
-                (int)camera1->yaw, (int)camera1->pitch, dynfov(), fovy, w, h);
+        render_world_new();
     }
     else
     {
@@ -1155,8 +1154,7 @@ void gl_drawframe(int w, int h, float changelod, float curfps, int elapsed)
 
     if(usenewworldrenderer)
     {
-        render_world_new(camera1->o.x, camera1->o.y, camera1->o.z, changelod,
-                (int)camera1->yaw, (int)camera1->pitch, dynfov(), fovy, w, h);
+        render_world_new();
 
     }
     else

--- a/source/src/rendergl.cpp
+++ b/source/src/rendergl.cpp
@@ -1024,7 +1024,20 @@ void gl_drawframe(int w, int h, float changelod, float curfps, int elapsed)
     effective_stencilshadow = mapoverride_nostencilshadows && !ignoreoverride_nostencilshadows ? 0 : stencilshadow;
     bool effective_waterreflect = waterreflect && !editmode && (!mapoverride_nowaterreflect || ignoreoverride_nowaterreflect);
 
-    dodynlights();
+    extern int usenewworldrenderer;
+
+    if(usenewworldrenderer)
+    {
+        extern void prepgpudata();
+        prepgpudata();
+        extern vector<vertex> verts;
+        verts.setsize(0);
+    }
+    else
+    {
+        dodynlights();
+    }
+
     drawminimap(w, h);
 
     recomputecamera();
@@ -1079,12 +1092,28 @@ void gl_drawframe(int w, int h, float changelod, float curfps, int elapsed)
 
     resetcubes();
 
-    render_world(camera1->o.x, camera1->o.y, camera1->o.z, changelod,
-            (int)camera1->yaw, (int)camera1->pitch, dynfov(), fovy, w, h);
+    if(usenewworldrenderer)
+    {
 
-    setupstrips();
+        extern void findvisibleblocks();
+        extern void findwaterquads();
+        extern void rendertrissky();
 
-    renderstripssky();
+        findvisibleblocks();
+        findwaterquads(); // comment this out for some fully sick fps gainz even when there's no water visible - needs to be fixed
+        rendertrissky();
+
+    }
+    else
+    {
+
+        render_world(camera1->o.x, camera1->o.y, camera1->o.z, changelod,
+                (int)camera1->yaw, (int)camera1->pitch, dynfov(), fovy, w, h);
+
+        setupstrips();
+
+        renderstripssky();
+    }
 
     glLoadIdentity();
     glRotatef(camera1->pitch, -1, 0, 0);
@@ -1102,7 +1131,17 @@ void gl_drawframe(int w, int h, float changelod, float curfps, int elapsed)
 
     setuptmu(0, "T * P x 2");
 
-    renderstrips();
+    if(usenewworldrenderer)
+    {
+        extern void render_world_new(float vx, float vy, float vh, float changelod, int yaw, int pitch, float fov, float fovy, int w, int h);
+        render_world_new(camera1->o.x, camera1->o.y, camera1->o.z, changelod,
+                (int)camera1->yaw, (int)camera1->pitch, dynfov(), fovy, w, h);
+
+    }
+    else
+    {
+        renderstrips();
+    }
 
 
     xtraverts = 0;

--- a/source/src/rendergl.cpp
+++ b/source/src/rendergl.cpp
@@ -1100,7 +1100,7 @@ void gl_drawframe(int w, int h, float changelod, float curfps, int elapsed)
         extern void rendertrissky();
 
         findvisibleblocks();
-        findwaterquads(); // comment this out for some fully sick fps gainz even when there's no water visible - needs to be fixed
+        findwaterquads();
         rendertrissky();
 
     }

--- a/source/src/rendergl.cpp
+++ b/source/src/rendergl.cpp
@@ -681,9 +681,10 @@ void drawreflection(float hf, int w, int h, float changelod, bool refract)
         glEnable(GL_SCISSOR_TEST);
     }
 
+    resetcubes();
+
     if(!usenewworldrenderer)
     {
-        resetcubes();
 
         render_world(camera1->o.x, camera1->o.y, refract ? camera1->o.z : hf, changelod,
                 (int)camera1->yaw, (refract ? 1 : -1)*(int)camera1->pitch, dynfov(), fovy, size, size);
@@ -712,6 +713,7 @@ void drawreflection(float hf, int w, int h, float changelod, bool refract)
 
     if(usenewworldrenderer)
     {
+        findvisibleblocks();
         rendertrissky();
     }
     else

--- a/source/src/rendergl.cpp
+++ b/source/src/rendergl.cpp
@@ -1059,10 +1059,9 @@ void gl_drawframe(int w, int h, float changelod, float curfps, int elapsed)
         extern vector<vertex> verts;
         verts.setsize(0);
     }
-    else
-    {
-        dodynlights();
-    }
+
+    dodynlights();
+
 
     drawminimap(w, h);
 

--- a/source/src/rendergl.cpp
+++ b/source/src/rendergl.cpp
@@ -1051,6 +1051,9 @@ void gl_drawframe(int w, int h, float changelod, float curfps, int elapsed)
     bool effective_waterreflect = waterreflect && !editmode && (!mapoverride_nowaterreflect || ignoreoverride_nowaterreflect);
 
     extern int usenewworldrenderer;
+    
+    extern int wdrawcalls;
+    wdrawcalls = 0;
 
     if(usenewworldrenderer)
     {
@@ -1225,5 +1228,6 @@ void gl_drawframe(int w, int h, float changelod, float curfps, int elapsed)
     glEnable(GL_FOG);
 
     undodynlights();
+
 }
 

--- a/source/src/worldio.cpp
+++ b/source/src/worldio.cpp
@@ -1161,6 +1161,7 @@ int load_world(char *mname)        // still supports all map formats that have e
     startmap(mname);
     res |= mapconfigerror;
     if(res) conoutf("\f3unresolved problems occurred during load_world(), warning: 0x%x", res);
+    postregenworldvbos();
     return res; // negative: error (no map loaded), zero: no problem, positive: some problems (bitmask value)
 }
 

--- a/source/src/worldlight.cpp
+++ b/source/src/worldlight.cpp
@@ -214,6 +214,8 @@ void calclight()
     postlightarea(bb);
     setvar("fullbright", 0);
     lastcalclight = totalmillis;
+
+    postregenworldvbos();
 }
 
 struct dlight

--- a/source/src/worldrender.cpp
+++ b/source/src/worldrender.cpp
@@ -337,10 +337,10 @@ void render_world(float vx, float vy, float vh, float changelod, int yaw, int pi
     render_floor = pitch<0.5f*fovy;
     render_ceil  = -pitch<0.5f*fovy;
 
-    DEBUGS(uint segstartmillis = SDL_GetTicks());
+    DEBUGCODE(uint segstartmillis = SDL_GetTicks());
     render_seg_new(vx, vy, vh, MAX_MIP, 0, 0, ssize>>MAX_MIP, ssize>>MAX_MIP);
-    DEBUGS(uint segmillis = SDL_GetTicks() - segstartmillis);
-    DEBUGS(
+    DEBUGCODE(uint segmillis = SDL_GetTicks() - segstartmillis);
+    DEBUGCODE(
            static uint lastdmillis = 0;
            if(segstartmillis - lastdmillis > 1000)
            {

--- a/source/src/worldrender.cpp
+++ b/source/src/worldrender.cpp
@@ -2,6 +2,11 @@
 // be rendered and how (depending on neighbouring cubes), then calls functions in rendercubes.cpp
 
 #include "cube.h"
+
+#define DEBUGCOND (worldrenderdebug == 1)
+
+VARP(worldrenderdebug, 0, 0, 1);
+
 void render_wall(sqr *o, sqr *s, int x1, int y1, int x2, int y2, int mip, sqr *d1, sqr *d2, bool topleft, int dir)
 {
     if(minimap) return;
@@ -332,7 +337,16 @@ void render_world(float vx, float vy, float vh, float changelod, int yaw, int pi
     render_floor = pitch<0.5f*fovy;
     render_ceil  = -pitch<0.5f*fovy;
 
+    DEBUGS(uint segstartmillis = SDL_GetTicks());
     render_seg_new(vx, vy, vh, MAX_MIP, 0, 0, ssize>>MAX_MIP, ssize>>MAX_MIP);
+    DEBUGS(uint segmillis = SDL_GetTicks() - segstartmillis);
+    DEBUGS(
+           static uint lastdmillis = 0;
+           if(segstartmillis - lastdmillis > 1000)
+           {
+               DEBUG("generated world geometry in " << segmillis << "ms");
+               lastdmillis = segstartmillis;
+           });
     mipstats(stats);
 }
 

--- a/source/src/worldrender.cpp
+++ b/source/src/worldrender.cpp
@@ -2,7 +2,6 @@
 // be rendered and how (depending on neighbouring cubes), then calls functions in rendercubes.cpp
 
 #include "cube.h"
-
 void render_wall(sqr *o, sqr *s, int x1, int y1, int x2, int y2, int mip, sqr *d1, sqr *d2, bool topleft, int dir)
 {
     if(minimap) return;


### PR DESCRIPTION
This is a fairly basic replacement for the old world renderer that allows bigger and far more open maps while performing reasonably well even on older hardware. Instead of the Cube engine's philosophy of generating all vertex data dynamically and then sending it to the GPU each frame, vertex data (for world geometry) is now generated once and stored on the GPU in VBOs, which allows for much better performance (in theory). In practice, performance relative to the old renderer varies depending on the map, hardware and drivers, but in general, the new renderer performs better in large, open areas and on newer hardware.

Use `/usenewworldrenderer (1|0)` to toggle between the new/old renderer, play around with `/bssize n` to see how it affects performance (default 32). 
