### PR TITLE
Joystick & gamepad support

### DIFF
--- a/config/keymap.cfg
+++ b/config/keymap.cfg
@@ -8,6 +8,49 @@ keymap -5 MOUSE5
 keymap -6 MOUSE6
 keymap -7 MOUSE7
 keymap -8 MOUSE8
+
+// Joystick buttons
+keymap -100 JOYSTICK1
+keymap -101 JOYSTICK2
+keymap -102 JOYSTICK3
+keymap -103 JOYSTICK4
+keymap -104 JOYSTICK5
+keymap -105 JOYSTICK6
+keymap -106 JOYSTICK7
+keymap -107 JOYSTICK8
+keymap -108 JOYSTICK9
+keymap -109 JOYSTICK10
+keymap -110 JOYSTICK11
+keymap -111 JOYSTICK12
+keymap -112 JOYSTICK13
+keymap -113 JOYSTICK14
+keymap -114 JOYSTICK15
+keymap -115 JOYSTICK16
+
+// Joystick axes acting as buttons (negative direction)
+keymap -200 JOYAXISDOWN1
+keymap -201 JOYAXISDOWN2
+keymap -202 JOYAXISDOWN3
+keymap -203 JOYAXISDOWN4
+keymap -204 JOYAXISDOWN5
+keymap -205 JOYAXISDOWN6
+keymap -206 JOYAXISDOWN7
+keymap -207 JOYAXISDOWN8
+keymap -208 JOYAXISDOWN9
+keymap -209 JOYAXISDOWN10
+
+// Joystick axes acting as buttons (positive direction)
+keymap -300 JOYAXISUP1
+keymap -301 JOYAXISUP2
+keymap -302 JOYAXISUP3
+keymap -303 JOYAXISUP4
+keymap -304 JOYAXISUP5
+keymap -305 JOYAXISUP6
+keymap -306 JOYAXISUP7
+keymap -307 JOYAXISUP8
+keymap -308 JOYAXISUP9
+keymap -309 JOYAXISUP10
+
 keymap 8 BACKSPACE
 keymap 9 TAB
 keymap 12 CLEAR

--- a/source/src/console.cpp
+++ b/source/src/console.cpp
@@ -582,10 +582,19 @@ void consolekey(int code, bool isdown, int cooked, SDLMod mod)
     }
 }
 
+VARP(printkeyevents, 0, 0, 1);
+
 void keypress(int code, bool isdown, int cooked, SDLMod mod)
 {
     keym *haskey = NULL;
     loopv(keyms) if(keyms[i].code==code) { haskey = &keyms[i]; break; }
+    if(haskey)
+    {
+        if(isdown && haskey->pressed)
+            return; // Filter out keypresses not separated by key releases
+        if(printkeyevents) conoutf("%s %s (%d)",
+            isdown ? "pressed" : "released", haskey->name, haskey->code);
+    }
     if(haskey && haskey->pressed) execbind(*haskey, isdown); // allow pressed keys to release
     else if(saycommandon) consolekey(code, isdown, cooked, mod);  // keystrokes go to commandline
     else if(!menukey(code, isdown, cooked, mod))                  // keystrokes go to menu

--- a/source/src/console.cpp
+++ b/source/src/console.cpp
@@ -592,7 +592,7 @@ void keypress(int code, bool isdown, int cooked, SDLMod mod)
     {
         if(isdown && haskey->pressed)
             return; // Filter out keypresses not separated by key releases
-        if(printkeyevents) conoutf("%s %s (%d)",
+        if(printkeyevents && isdown) conoutf("%s %s (%d)",
             isdown ? "pressed" : "released", haskey->name, haskey->code);
     }
     if(haskey && haskey->pressed) execbind(*haskey, isdown); // allow pressed keys to release

--- a/source/src/main.cpp
+++ b/source/src/main.cpp
@@ -826,7 +826,8 @@ static int ignoremouse = 5;
 SDL_Joystick *joystick = NULL;
 VARP(joystickaxisx, 0, 0, 100);
 VARP(joystickaxisy, 0, 1, 100);
-FVARP(joysensitivity, 1e-3f, 3.0f, 1000.0f);
+FVARP(joysensx, 1e-3f, 1.0f, 1000.0f);
+FVARP(joysensy, 1e-3f, 0.5f, 1000.0f);
 VARP(joyaxisfilter, 0, 0, 30000);
 FVARP(joyresponsecurvexpt, 0.1f, 1.0f, 10.0f);
 VARP(joytriggerthreshold, 1, 16000, 30000);
@@ -856,7 +857,7 @@ void joystickinput(int &tdx, int &tdy)
 {
     if(!joystick) return;
 
-    float jfactor = curtime * 1e-4f * joysensitivity;
+    float jfactor = curtime * 1e-4f;
     int jx = 0, jy = 0;
     if(joystickaxisx >= 0)
         jx = joystickfilteraxis(SDL_JoystickGetAxis(joystick, joystickaxisx));
@@ -865,8 +866,8 @@ void joystickinput(int &tdx, int &tdy)
 
     static float jdx = 0.0f, jdy = 0.0f;
 
-    jdx += jx * jfactor * joystickaccelerate(jx);
-    jdy += jy * jfactor * joystickaccelerate(jy);
+    jdx += jx * jfactor * joystickaccelerate(jx) * joysensx;
+    jdy += jy * jfactor * joystickaccelerate(jy) * joysensy;
 
     joystickmoveaxis(jdx, tdx);
     joystickmoveaxis(jdy, tdy);


### PR DESCRIPTION
This is a simple implementation using the SDL joystick API. New keys to bind to are available; JOYSTICK1 to JOYSTICK16 for ordinary buttons, JOYAXISUP1 to JOYAXISUP10 and JOYAXISDOWN1 to JOYAXISDOWN10 for axes (including analog sticks as well as pressure-sensitive buttons such as the triggers on xbox controllers).

Use `printkeyevents` option to dump all key press events to console; you will need this to find which keys/axes are which. Button and axis numbering varies between controllers and platforms; XBone controller on Windows, 360 on Windows and 360 controller on Linux all differ slightly, for example, so you'll have to set the bindings manually for your controller and system.

`joystickaxisx` and `joystickaxisy` are used to set the controller axes for controlling the view direction. `joysensitivity` and `joyresponsecurvexpt` are used to adjust controller behaviour for looking, but since the controller code is essentially piggybacking on the mouse code, both of these are applied in addition to (but before) mouse sensitivity and acceleration.
