### PR TITLE
Set hitsound priority to highest

### DIFF
--- a/source/src/audiomanager.cpp
+++ b/source/src/audiomanager.cpp
@@ -773,9 +773,12 @@ bool staticreference::operator==(const worldobjreference &other)
 
 audiomanager audiomgr;
 
-COMMANDF(sound, "i", (int *n)
+const char *prioritynames[] = {"LOW", "NORMAL", "HIGH", "HIGHEST", ""};
+
+COMMANDF(sound, "is", (int *n, char *priorityname)
 {
-    audiomgr.playsound(*n);
+    int priority = getlistindex(priorityname, prioritynames, true, SP_NORMAL);
+    audiomgr.playsound(*n, priority);
 });
 
 COMMANDF(applymapsoundchanges, "", (){

--- a/source/src/clientgame.cpp
+++ b/source/src/clientgame.cpp
@@ -860,7 +860,7 @@ void dodamage(int damage, playerent *pl, playerent *actor, int gun, bool gib, bo
 
     if(actor==h && pl!=actor)
     {
-        if( (hitsound == 1 || (hitsound && h != player1) ) && lasthit != lastmillis) audiomgr.playsound(S_HITSOUND, SP_HIGH);
+        if( (hitsound == 1 || (hitsound && h != player1) ) && lasthit != lastmillis) audiomgr.playsound(S_HITSOUND, SP_HIGHEST);
         lasthit = lastmillis;
     }
 


### PR DESCRIPTION
* Local hitsound priority (/hitsound 2): intended `HIGHEST`, actual `NORMAL` - `sound` CubeScript command didn't accept the second argument (priority). This bug has been pointed out by Sveark.
* Server hitsound priority (/hitsound 1): was `HIGH`, set to `HIGHEST`.

Couldn't find `doc/reference.xml` to update docs for `sound` in this repo.
