### PR TITLE
Added "dropflag" closer to WASD

### DIFF
--- a/config/resetbinds.cfg
+++ b/config/resetbinds.cfg
@@ -183,7 +183,7 @@ editbind U undo
 bind V key_showmenuvoicecom
 editbind V paste
 bind W forward
-bind X []
+bind X [dropflag]
 editbind X editkey_scroll_walluppertex
 bind Y key_teamchat
 bind Z []


### PR DESCRIPTION
Added "dropflag", a tactical command closer to WASD. "dropflag" is presently located on backspace. This change duplicates the function across the keyboard.The new key proposed is "X", previously unused.