### PR TITLE
fix compiling warnings in GCC

### DIFF
--- a/source/src/client.cpp
+++ b/source/src/client.cpp
@@ -396,7 +396,9 @@ void addmsg(int type, const char *fmt, ...)
             case 's':
             {
                 const char *t = va_arg(args, const char *);
-                if(t) sendstring(t, p); nums++; break;
+                if(t) sendstring(t, p);
+                nums++;
+                break;
             }
         }
         va_end(args);

--- a/source/src/clients2c.cpp
+++ b/source/src/clients2c.cpp
@@ -350,7 +350,8 @@ void showhudextras(char hudextras, char value){
             {
                 playerent *p = getclient(teamworkid);
                 if (!p || p == player1) teamworkid = -1;
-                else outf("\f5you covered %s",p->name); break;
+                else outf("\f5you covered %s",p->name);
+                break;
             }
         default:
         {


### PR DESCRIPTION
OS: windows 7
Compiler: gcc version 7.3.0 (Rev2, Built by MSYS2 project)