### PR TITLE
Patch needed for limiting bot vote in multiplayer

### DIFF
--- a/config/servercmdline.txt
+++ b/config/servercmdline.txt
@@ -91,6 +91,8 @@
 // --demotimestampformat="%H%M_%Y%m%d"      // default: "%Y%m%d_%H%M"
 // --demotimelocal=1                        // default: 0
 
+// -Q    // Set the number of maximum player allowed for a single ip, 0 disable this, default 2
+
 // don't use these switches, unless you really know what you're doing:
 
 // -u     // uprate

--- a/source/src/protos.h
+++ b/source/src/protos.h
@@ -1128,7 +1128,7 @@ struct serverconfigfile
 // server commandline parsing
 struct servercommandline
 {
-    int uprate, serverport, syslogfacility, filethres, syslogthres, maxdemos, maxclients, kickthreshold, banthreshold, verbose, incoming_limit, afk_limit, ban_time, demotimelocal;
+    int uprate, serverport, syslogfacility, filethres, syslogthres, maxdemos, maxclients, kickthreshold, banthreshold, verbose, incoming_limit, afk_limit, ban_time, demotimelocal, maxplayer_for_ip;
     const char *ip, *master, *logident, *serverpassword, *adminpasswd, *demopath, *maprot, *pwdfile, *blfile, *nbfile, *infopath, *motdpath, *forbidden, *demofilenameformat, *demotimestampformat;
     bool logtimestamp, demo_interm, loggamestatus;
     string motd, servdesc_full, servdesc_pre, servdesc_suf, voteperm, mapperm;
@@ -1136,7 +1136,7 @@ struct servercommandline
     vector<const char *> adminonlymaps;
 
     servercommandline() :   uprate(0), serverport(CUBE_DEFAULT_SERVER_PORT), syslogfacility(6), filethres(-1), syslogthres(-1), maxdemos(5),
-                            maxclients(DEFAULTCLIENTS), kickthreshold(-5), banthreshold(-6), verbose(0), incoming_limit(10), afk_limit(45000), ban_time(20*60*1000), demotimelocal(0),
+                            maxclients(DEFAULTCLIENTS), kickthreshold(-5), banthreshold(-6), verbose(0), incoming_limit(10), afk_limit(45000), ban_time(20*60*1000), demotimelocal(0), maxplayer_for_ip(2),
                             ip(""), master(NULL), logident(""), serverpassword(""), adminpasswd(""), demopath(""),
                             maprot("config/maprot.cfg"), pwdfile("config/serverpwd.cfg"), blfile("config/serverblacklist.cfg"), nbfile("config/nicknameblacklist.cfg"),
                             infopath("config/serverinfo"), motdpath("config/motd"), forbidden("config/forbidden.cfg"),
@@ -1270,6 +1270,7 @@ struct servercommandline
                 clfilenesting--;
                 break;
             }
+            case 'Q': maxplayer_for_ip = ai; break;
             default: return false;
         }
         return true;

--- a/source/src/server.cpp
+++ b/source/src/server.cpp
@@ -4061,7 +4061,7 @@ void serverslice(uint timeout)   // main server update, called from cube main lo
                 int count = 0;
                 if(scl.maxplayer_for_ip > 0){
                     for (int i = 0 ; i < clients.length(); i++){
-                        if(clients[i]->peer->address.host == event.peer->address.host){
+                        if(clients[i]->type==ST_TCPIP && clients[i]->peer->address.host == event.peer->address.host){
                             count++;
                         }
                     }


### PR DESCRIPTION
There are some people that use a lot of bot to ban people in game or to damage game,
i think that limiting the connection of player from the same ip is good mode for limiting damage to the game, i defaulted to 2 to allow a local multiplayer vs online people and if you set the command line switch to 0 you disable this protection enabling more player from same ip (good for local server in lan party ex) the patch is very little and don't broke actual ac protocol i return reason 19 as message of server not accepting the player "auto-kick - abnormal client behavior detected"