### PR TITLE
Integrated damage into scoreboard

### DIFF
--- a/source/src/clients2c.cpp
+++ b/source/src/clients2c.cpp
@@ -792,6 +792,10 @@ void parsemessages(int cn, playerent *d, ucharbuf &p, bool demo = false)
                 if(!target || !actor) break;
                 target->armour = armour;
                 target->health = health;
+                if (!isteam(actor->team, target->team)) {
+                    // tking shouldn't increase damage score
+                    actor->damage += damage;
+                }
                 dodamage(damage, target, actor, -1, type==SV_GIBDAMAGE, false);
                 actor->pstatdamage[gun]+=damage; //NEW
                 break;
@@ -871,6 +875,7 @@ void parsemessages(int cn, playerent *d, ucharbuf &p, bool demo = false)
                     d->deaths = deaths;
                     d->points = points;
                     d->tks = teamkills;
+                    // TODO: include damage
                     if(d!=player1)
                     {
                         d->setprimary(primary);
@@ -899,6 +904,7 @@ void parsemessages(int cn, playerent *d, ucharbuf &p, bool demo = false)
                     ds.frags = getint(p);
                     ds.deaths = getint(p);
                     ds.points = getint(p);
+                    // TODO: include damage
                 }
                 break;
             }

--- a/source/src/entity.h
+++ b/source/src/entity.h
@@ -425,6 +425,7 @@ public:
     int frags, flagscore, deaths, points, tks;
     int lastaction, lastmove, lastpain, lastvoicecom, lastdeath;
     int clientrole;
+    unsigned int damage;
     bool attacking;
     string name;
     int team;
@@ -450,7 +451,7 @@ public:
     bool ignored, muted;
     bool nocorpse;
 
-    playerent() : curskin(0), clientnum(-1), lastupdate(0), plag(0), ping(0), address(0), lifesequence(0), frags(0), flagscore(0), deaths(0), points(0), tks(0), lastpain(0), lastvoicecom(0), lastdeath(0), clientrole(CR_DEFAULT),
+    playerent() : curskin(0), clientnum(-1), lastupdate(0), plag(0), ping(0), address(0), lifesequence(0), frags(0), flagscore(0), damage(0), deaths(0), points(0), tks(0), lastpain(0), lastvoicecom(0), lastdeath(0), clientrole(CR_DEFAULT),
                   team(TEAM_SPECT), spectatemode(SM_NONE), eardamagemillis(0), maxroll(ROLLMOVDEF), maxrolleffect(ROLLEFFDEF), movroll(0), effroll(0),
                   prevweaponsel(NULL), weaponsel(NULL), nextweaponsel(NULL), primweap(NULL), nextprimweap(NULL), lastattackweapon(NULL),
                   smoothmillis(-1),

--- a/source/src/protos.h
+++ b/source/src/protos.h
@@ -610,7 +610,7 @@ extern void votecount(int v);
 extern void clearvote();
 
 // scoreboard
-struct discscore { int team, flags, frags, deaths, points; char name[MAXNAMELEN + 1]; };
+struct discscore { int team, flags, frags, deaths, points, damage; char name[MAXNAMELEN + 1]; };
 extern vector<discscore> discscores;
 extern void showscores(bool on);
 extern void renderscores(void *menu, bool init);

--- a/source/src/scoreboard.cpp
+++ b/source/src/scoreboard.cpp
@@ -19,6 +19,7 @@ VARFP(sc_frags,      0,  1, 100, needscoresreorder = true);
 VARFP(sc_deaths,    -1,  2, 100, needscoresreorder = true);
 VARFP(sc_ratio,     -1, -1, 100, needscoresreorder = true);
 VARFP(sc_score,     -1,  4, 100, needscoresreorder = true);
+VARFP(sc_damage,     0,  3, 100, needscoresreorder = true);
 VARFP(sc_lag,       -1,  5, 100, needscoresreorder = true);
 VARFP(sc_clientnum,  0,  6, 100, needscoresreorder = true);
 VARFP(sc_name,       0,  7, 100, needscoresreorder = true);
@@ -86,9 +87,9 @@ vector<discscore> discscores;
 
 struct teamscore
 {
-    int team, frags, deaths, flagscore, points;
+    int team, frags, deaths, flagscore, points, damage;
     vector<playerent *> teammembers;
-    teamscore(int t) : team(t), frags(0), deaths(0), flagscore(0), points(0) {}
+    teamscore(int t) : team(t), frags(0), deaths(0), flagscore(0), points(0), damage(0) {}
 
     void addplayer(playerent *d)
     {
@@ -97,6 +98,7 @@ struct teamscore
         frags += d->frags;
         deaths += d->deaths;
         points += d->points;
+        damage += d->damage;
         if(m_flags) flagscore += d->flagscore;
     }
 
@@ -105,6 +107,7 @@ struct teamscore
         frags += d.frags;
         deaths += d.deaths;
         points += d.points;
+        damage += d.damage;
         if(m_flags) flagscore += d.flags;
     }
 };
@@ -195,6 +198,7 @@ void renderdiscscores(int team)
         line.addcol(sc_frags, "%d", d.frags);
         line.addcol(sc_deaths, "%d", d.deaths);
         line.addcol(sc_ratio, "%.2f", SCORERATIO(d.frags, d.deaths));
+        line.addcol(sc_damage, "%i", d.damage);
         if(multiplayer(NULL) || watchingdemo) line.addcol(sc_score, "%d", max(d.points, 0));
         line.addcol(sc_lag, "%s", clag);
         line.addcol(sc_clientnum, "DISC");
@@ -226,6 +230,7 @@ void renderscore(playerent *d)
     if(m_flags) line.addcol(sc_flags, "%d", d->flagscore);
     line.addcol(sc_frags, "%d", d->frags);
     line.addcol(sc_deaths, "%d", d->deaths);
+    line.addcol(sc_damage, "%i", d->damage);
     line.addcol(sc_ratio, "%.2f", SCORERATIO(d->frags, d->deaths));
     if(multiplayer(NULL) || watchingdemo)
     {
@@ -259,6 +264,7 @@ void renderteamscore(teamscore *t)
     line.addcol(sc_frags, "%d", t->frags);
     line.addcol(sc_deaths, "%d", t->deaths);
     line.addcol(sc_ratio, "%.2f", SCORERATIO(t->frags, t->deaths));
+    line.addcol(sc_damage, "%i", t->damage);
     if(multiplayer(NULL) || watchingdemo)
     {
         line.addcol(sc_score, "%d", max(t->points, 0));
@@ -286,6 +292,7 @@ void reorderscorecolumns()
     sscore.addcol(sc_frags, "frags");
     sscore.addcol(sc_deaths, "deaths");
     sscore.addcol(sc_ratio, "ratio");
+    sscore.addcol(sc_damage, "damage");
     if(multiplayer(NULL) || watchingdemo)
     {
         sscore.addcol(sc_score, "score");


### PR DESCRIPTION
Fixes #216.

I couldn't test whether the damage is integrated into screenshots, since this functionality seems to be broken (although there was no error message, solely the printed screenshot directory was empty).
Moreover, `SV_RESUME` and `SV_DISCSCORES` messages are lacking support yet as indicated by the TODOs.
Theorectically, one might consider using `long` instead of `unsigned int` to prevent overflow.