### PR TITLE
#221 Client network protocol and #223 nade physics

### DIFF
--- a/source/src/client.cpp
+++ b/source/src/client.cpp
@@ -395,8 +395,9 @@ void addmsg(int type, const char *fmt, ...)
             }
             case 's':
             {
-                const char *t = va_arg(args, const char *);
-                if(t) sendstring(t, p); nums++; break;
+                sendstring(va_arg(args, const char*), p); 
+                nums++; 
+                break;
             }
         }
         va_end(args);

--- a/source/src/physics.cpp
+++ b/source/src/physics.cpp
@@ -82,7 +82,7 @@ bool plcollide(physent *d, physent *o, float &headspace, float &hi, float &lo)  
     if((d->type==ENT_PLAYER && o->type==ENT_PLAYER ? dr.sqrxy() < r*r : fabs(dr.x)<r && fabs(dr.y)<r) && dr.dotxy(d->vel) >= 0.0f)
     {
         if(d->o.z-deyeheight<o->o.z-oeyeheight) { if(o->o.z-oeyeheight<hi) hi = o->o.z-oeyeheight-1; }
-        else if(o->o.z+o->aboveeye>lo) lo = o->o.z+o->aboveeye+1;
+        else if(o->o.z+o->aboveeye>lo) lo = o->o.z+o->aboveeye;
 
         if(fabs(o->o.z-d->o.z)<o->aboveeye+deyeheight) { hitplayer = o; return true; }
         headspace = d->o.z-o->o.z-o->aboveeye-deyeheight;


### PR DESCRIPTION
Fix for issues https://github.com/assaultcube/AC/issues/221 and https://github.com/assaultcube/AC/issues/223

Notes:
The physical spacing above a players head has been calculated wrong. I am not sure but this might be a measure that is as old as cube1 engine. The fix will also impact the spacing if a player stands on top of another player, see screenshots. This might be a problem for jumpmaps or tactical spots that can only be reached by two collaborating players.

BEFORE:
![before](https://user-images.githubusercontent.com/78469463/107353458-5a414900-6acd-11eb-859a-7b018f42d864.jpg)

AFTER:
![after](https://user-images.githubusercontent.com/78469463/107353473-5f9e9380-6acd-11eb-9bb0-ef57a51cb7ae.jpg)

