### PR TITLE
Get macos launcher building

### DIFF
--- a/source/xcode/Launcher.m
+++ b/source/xcode/Launcher.m
@@ -291,7 +291,7 @@ static int numberForKey(CFDictionaryRef desc, CFStringRef key)
     NSString *key;
     while ((key = [e nextObject])) 
     {
-        int pos = [key rangeOfString:@"bind."].location;
+        NSUInteger pos = [key rangeOfString:@"bind."].location;
         if(pos == NSNotFound || pos > 5) continue;
         [arr addObject:[NSDictionary dictionaryWithObjectsAndKeys: //keys used in nib
             [key substringFromIndex:pos+5], @"key",

--- a/source/xcode/Launcher.m
+++ b/source/xcode/Launcher.m
@@ -178,7 +178,6 @@ static int numberForKey(CFDictionaryRef desc, CFStringRef key)
     }
     NSToolbar *toolbar = [[NSToolbar alloc] initWithIdentifier:@""];
     [toolbar setDelegate:self]; 
-    [toolbar setAllowsUserCustomization:NO]; 
     [toolbar setAutosavesConfiguration:NO];  
     [window setToolbar:toolbar]; 
     [toolbar release];


### PR DESCRIPTION
Building the launcher was failing.

`[toolbar setAllowsUserCustomization:NO]` was one of the reasons and it defaults to `NO` anyway so I removed it.

`pos` wasn't matching `NSNotFound` on 64 bit systems.  `location` is an `NSUInteger`, so I've just changed the type.