### PR TITLE
Add OOB check

### DIFF
--- a/source/src/clients2c.cpp
+++ b/source/src/clients2c.cpp
@@ -814,6 +814,9 @@ void parsemessages(int cn, playerent *d, ucharbuf &p, bool demo = false)
 //                         medals_arrived=1;
                         loopi(medals) {
                             int mcn=getint(p); int mtype=getint(p); int mitem=getint(p);
+                            if(mtype >= END_MDS || mtype<0){
+                                break;
+                            }
                             a_medals[mtype].assigned=1;
                             a_medals[mtype].cn=mcn;
                             a_medals[mtype].item=mitem;

--- a/source/src/clients2c.cpp
+++ b/source/src/clients2c.cpp
@@ -747,6 +747,10 @@ void parsemessages(int cn, playerent *d, ucharbuf &p, bool demo = false)
             case SV_RELOAD:
             {
                 int cn = getint(p), gun = getint(p);
+                if(!valid_weapon(gun)){
+                    break;
+                }
+
                 playerent *p = getclient(cn);
                 if(p && p!=player1) p->weapons[gun]->reload(false);
                 break;

--- a/source/src/clients2c.cpp
+++ b/source/src/clients2c.cpp
@@ -790,7 +790,7 @@ void parsemessages(int cn, playerent *d, ucharbuf &p, bool demo = false)
                     armour = getint(p),
                     health = getint(p);
                 playerent *target = getclient(tcn), *actor = getclient(acn);
-                if(!target || !actor) break;
+                if(!target || !actor || valid_weapon(gun)) break;
                 target->armour = armour;
                 target->health = health;
                 dodamage(damage, target, actor, -1, type==SV_GIBDAMAGE, false);


### PR DESCRIPTION
When the client parses messages sent by the server, client does not perform appropriate OOB check.