### PR TITLE
Spectator fov bugfix

### DIFF
--- a/source/src/clients2c.cpp
+++ b/source/src/clients2c.cpp
@@ -181,6 +181,8 @@ void parsepositions(ucharbuf &p)
                 sniperrifle *sr = (sniperrifle *)d->weaponsel;
                 sr->scoped = d->scoping = (f & (1 << 5)) ? true : false;
             }
+            else d->scoping = false;
+
             d->roll = 0;
             d->vel = vel;
             int ft = f & 0x1f;


### PR DESCRIPTION
This is proposal to solve #283 .

Actual FOV is returned by function `dynfov()` from file rendergl.cpp. The issue was that property `scoping` which is required to determine FOV is updated only when player is alive and holds sniper.

Now it is no longer necessary to hold sniper to update that variable.