### PR TITLE
togglespect updated to spectatemode 5 changes

### DIFF
--- a/source/src/clientgame.cpp
+++ b/source/src/clientgame.cpp
@@ -1789,8 +1789,10 @@ void togglespect() // cycle through all spectating modes
     else
     {
         int mode;
+        bool notmatchnotprivate = (servstate.mastermode != MM_MATCH && servstate.mastermode != MM_PRIVATE);
+        bool sm56forbidden = (player1->state == CS_DEAD || player1->team == TEAM_CLA_SPECT || player1->team == TEAM_RVSF_SPECT || notmatchnotprivate);
         if(player1->spectatemode==SM_NONE) mode = SM_FOLLOW1ST; // start with 1st person spect
-        else mode = SM_FOLLOW1ST + ((player1->spectatemode - SM_FOLLOW1ST + 1) % (SM_OVERVIEW-SM_FOLLOW1ST)); // replace SM_OVERVIEW by SM_NUM to enable overview mode
+        else mode = SM_FOLLOW1ST + ((player1->spectatemode - SM_FOLLOW1ST + 1) % ((sm56forbidden ? SM_FLY : SM_OVERVIEW)-SM_FOLLOW1ST)); // replace SM_OVERVIEW by SM_NUM to enable overview mode
         spectatemode(mode);
     }
 }

--- a/source/src/clientgame.cpp
+++ b/source/src/clientgame.cpp
@@ -1734,7 +1734,7 @@ void setfollowplayer(int cn)
 }
 COMMANDF(setfollowplayer, "i", (int *cn) { setfollowplayer(*cn); });
 
-// macros to determine when SM_OVERVIEW and SM_FLY are permited
+// macros to determine when SM_OVERVIEW and SM_FLY are permitted
 // the spectate mode SM_OVERVIEW is like a radar hack and therefore is only allowed under certain conditions
 #define NOT_MATCH_NOT_PRIVATE (servstate.mastermode != MM_MATCH && servstate.mastermode != MM_PRIVATE)
 #define SM_56_FOBRIDDEN (player1->state == CS_DEAD || player1->team == TEAM_CLA_SPECT || player1->team == TEAM_RVSF_SPECT || NOT_MATCH_NOT_PRIVATE)
@@ -1744,10 +1744,7 @@ void spectatemode(int mode)
 {
     if((player1->state != CS_DEAD && player1->state != CS_SPECTATE && !team_isspect(player1->team)) || (!m_teammode && !team_isspect(player1->team) && servstate.mastermode == MM_MATCH)) return;  // during ffa matches only SPECTATORS can spectate
     if(mode == player1->spectatemode || (m_botmode && mode != SM_FLY)) return;
-    if(mode == SM_OVERVIEW || mode == SM_FLY)
-    {
-        if(SM_56_FOBRIDDEN) return;
-    }
+    if((mode == SM_OVERVIEW || mode == SM_FLY) && SM_56_FOBRIDDEN) return;
     showscores(false);
     switch(mode)
     {

--- a/source/src/clientgame.cpp
+++ b/source/src/clientgame.cpp
@@ -1756,6 +1756,7 @@ void spectatemode(int mode)
         case SM_FOLLOW3RD_TRANSPARENT:
         {
             if(players.length() && updatefollowplayer()) break;
+            else if (smoverviewflyforbidden()) mode = SM_DEATHCAM;
             else mode = SM_FLY;
         }
         case SM_FLY:

--- a/source/src/clientgame.cpp
+++ b/source/src/clientgame.cpp
@@ -1738,7 +1738,7 @@ COMMANDF(setfollowplayer, "i", (int *cn) { setfollowplayer(*cn); });
 bool smoverviewflyforbidden()
 {
     bool notmatchnotprivate = servstate.mastermode != MM_MATCH && servstate.mastermode != MM_PRIVATE;
-    return (player1->state == CS_DEAD || player1->team == TEAM_CLA_SPECT || player1->team == TEAM_RVSF_SPECT || notmatchnotprivate);
+    return (player1->team != TEAM_SPECT || notmatchnotprivate);
 }
 
 // set new spect mode

--- a/source/src/clientgame.cpp
+++ b/source/src/clientgame.cpp
@@ -1738,7 +1738,7 @@ COMMANDF(setfollowplayer, "i", (int *cn) { setfollowplayer(*cn); });
 bool smoverviewflyforbidden()
 {
     bool notmatchnotprivate = servstate.mastermode != MM_MATCH && servstate.mastermode != MM_PRIVATE;
-    return (player1->team != TEAM_SPECT || notmatchnotprivate);
+    return ((player1->team != TEAM_SPECT || notmatchnotprivate) && !watchingdemo);
 }
 
 // set new spect mode

--- a/source/src/clientgame.cpp
+++ b/source/src/clientgame.cpp
@@ -1734,6 +1734,11 @@ void setfollowplayer(int cn)
 }
 COMMANDF(setfollowplayer, "i", (int *cn) { setfollowplayer(*cn); });
 
+// macros to determine when SM_OVERVIEW and SM_FLY are permited
+// the spectate mode SM_OVERVIEW is like a radar hack and therefore is only allowed under certain conditions
+#define NOT_MATCH_NOT_PRIVATE (servstate.mastermode != MM_MATCH && servstate.mastermode != MM_PRIVATE)
+#define SM_56_FOBRIDDEN (player1->state == CS_DEAD || player1->team == TEAM_CLA_SPECT || player1->team == TEAM_RVSF_SPECT || NOT_MATCH_NOT_PRIVATE)
+
 // set new spect mode
 void spectatemode(int mode)
 {
@@ -1741,9 +1746,7 @@ void spectatemode(int mode)
     if(mode == player1->spectatemode || (m_botmode && mode != SM_FLY)) return;
     if(mode == SM_OVERVIEW || mode == SM_FLY)
     {
-        // the spectate mode SM_OVERVIEW is like a radar hack and therefore is only allowed under certain conditions
-        bool notmatchnotprivate = (servstate.mastermode != MM_MATCH && servstate.mastermode != MM_PRIVATE);
-        if(player1->state == CS_DEAD || player1->team == TEAM_CLA_SPECT || player1->team == TEAM_RVSF_SPECT || notmatchnotprivate) return;
+        if(SM_56_FOBRIDDEN) return;
     }
     showscores(false);
     switch(mode)
@@ -1789,10 +1792,8 @@ void togglespect() // cycle through all spectating modes
     else
     {
         int mode;
-        bool notmatchnotprivate = (servstate.mastermode != MM_MATCH && servstate.mastermode != MM_PRIVATE);
-        bool sm56forbidden = (player1->state == CS_DEAD || player1->team == TEAM_CLA_SPECT || player1->team == TEAM_RVSF_SPECT || notmatchnotprivate);
         if(player1->spectatemode==SM_NONE) mode = SM_FOLLOW1ST; // start with 1st person spect
-        else mode = SM_FOLLOW1ST + ((player1->spectatemode - SM_FOLLOW1ST + 1) % ((sm56forbidden ? SM_FLY : SM_OVERVIEW)-SM_FOLLOW1ST)); // replace SM_OVERVIEW by SM_NUM to enable overview mode
+        else mode = SM_FOLLOW1ST + ((player1->spectatemode - SM_FOLLOW1ST + 1) % ((SM_56_FOBRIDDEN ? SM_FLY : SM_OVERVIEW)-SM_FOLLOW1ST)); // replace SM_OVERVIEW by SM_NUM to enable overview mode
         spectatemode(mode);
     }
 }

--- a/source/src/clientgame.cpp
+++ b/source/src/clientgame.cpp
@@ -1734,17 +1734,19 @@ void setfollowplayer(int cn)
 }
 COMMANDF(setfollowplayer, "i", (int *cn) { setfollowplayer(*cn); });
 
-// macros to determine when SM_OVERVIEW and SM_FLY are permitted
 // the spectate mode SM_OVERVIEW is like a radar hack and therefore is only allowed under certain conditions
-#define NOT_MATCH_NOT_PRIVATE (servstate.mastermode != MM_MATCH && servstate.mastermode != MM_PRIVATE)
-#define SM_56_FOBRIDDEN (player1->state == CS_DEAD || player1->team == TEAM_CLA_SPECT || player1->team == TEAM_RVSF_SPECT || NOT_MATCH_NOT_PRIVATE)
+bool smoverviewflyforbidden()
+{
+    bool notmatchnotprivate = servstate.mastermode != MM_MATCH && servstate.mastermode != MM_PRIVATE;
+    return (player1->state == CS_DEAD || player1->team == TEAM_CLA_SPECT || player1->team == TEAM_RVSF_SPECT || notmatchnotprivate);
+}
 
 // set new spect mode
 void spectatemode(int mode)
 {
     if((player1->state != CS_DEAD && player1->state != CS_SPECTATE && !team_isspect(player1->team)) || (!m_teammode && !team_isspect(player1->team) && servstate.mastermode == MM_MATCH)) return;  // during ffa matches only SPECTATORS can spectate
     if(mode == player1->spectatemode || (m_botmode && mode != SM_FLY)) return;
-    if((mode == SM_OVERVIEW || mode == SM_FLY) && SM_56_FOBRIDDEN) return;
+    if((mode == SM_OVERVIEW || mode == SM_FLY) && smoverviewflyforbidden()) return;
     showscores(false);
     switch(mode)
     {
@@ -1790,7 +1792,7 @@ void togglespect() // cycle through all spectating modes
     {
         int mode;
         if(player1->spectatemode==SM_NONE) mode = SM_FOLLOW1ST; // start with 1st person spect
-        else mode = SM_FOLLOW1ST + ((player1->spectatemode - SM_FOLLOW1ST + 1) % ((SM_56_FOBRIDDEN ? SM_FLY : SM_OVERVIEW)-SM_FOLLOW1ST)); // replace SM_OVERVIEW by SM_NUM to enable overview mode
+        else mode = SM_FOLLOW1ST + ((player1->spectatemode - SM_FOLLOW1ST + 1) % ((smoverviewflyforbidden() ? SM_FLY : SM_OVERVIEW)-SM_FOLLOW1ST)); // replace SM_OVERVIEW by SM_NUM to enable overview mode
         spectatemode(mode);
     }
 }


### PR DESCRIPTION
In cases where `SM_FLY` (SM5) is forbidden, togglespect now correctly returns to `SM_FOLLOW1ST`. Rules were copy-pasted from function `spectatemode` few lines above.

This is response to issue #342.