### PR TITLE
server side of getmap for non-coop

### DIFF
--- a/source/src/server.cpp
+++ b/source/src/server.cpp
@@ -3772,6 +3772,20 @@ void process(ENetPacket *packet, int sender, int chan)
                     cl->mapchange(true);
                     sendwelcome(cl, 2); // resend state properly
                 }
+                else
+                {
+                    packetbuf p(MAXTRANS + sg->coop_cgzlen + sg->coop_cfglengz, ENET_PACKET_FLAG_RELIABLE);
+                    putint(p, SV_RECVMAP);
+                    sendstring(sg->smapname, p);
+                    putint(p, sg->curmap->cgzlen);
+                    putint(p, sg->curmap->cfglen);
+                    putint(p, sg->curmap->cfggzlen);
+                    p.put(sg->curmap->cgzraw, sg->curmap->cgzlen);
+                    if (sg->curmap->cgzlen) p.put(sg->curmap->cfgrawgz, sg->curmap->cfggzlen);
+                    sendpacket(cl->clientnum, 2, p.finalize());
+                    cl->mapchange(true);
+                    sendwelcome(cl, 2); // resend state properly
+                }
                 break;
             }
 


### PR DESCRIPTION
Seems like server side of getmap was not fully re-implemented after refactoring.
This commit returns getmap functonallity.

Tested:
- Custom map "blah" that is present on server but not present on client is sucessfully downloaded and played in DM, using single command `DM blah` (expected behaviour)
- Custom map "blah" that is present on server but not present on client is sucessfully used in coop, using:
    1.  `coop blah`
    2.  `getmap`

Ongoing investigation:
- Under certain circumstances server map gets broken
- Displayed? map revision remains 0 after an upload

 #297 