### PR TITLE
fix problem with gibmessage GRENADE

### DIFF
--- a/config/menus_settings.cfg
+++ b/config/menus_settings.cfg
@@ -257,6 +257,7 @@ menuitemtextinput "Knife: "    [ gibmessage KNIFE ]   [ gibmessage KNIFE $arg1 ]
 menuitemtextinput "Shotgun: "  [ gibmessage SHOTGUN ] [ gibmessage SHOTGUN $arg1 ] [] 15
 menuitemtextinput "Sniper: "   [ gibmessage SNIPER ]  [ gibmessage SNIPER $arg1 ] [] 15
 menuitemtextinput "Grenades: " [ gibmessage GRENADE ] [ gibmessage GRENADE $arg1 ] [] 15
+menuitem "" -1
 
 ////  Main > Settings > Gameplay > Bot settings  ////
 // see menus_bot.cfg


### PR DESCRIPTION
after changing the message and exiting menu the message was not being saved, it was necessary to confirm change using "enter", added menuitem "" -1 below makes this not happen anymore.