### PR TITLE
fix pointatent

### DIFF
--- a/config/menus_edit.cfg
+++ b/config/menus_edit.cfg
@@ -1400,7 +1400,7 @@ menuitemcheckbox  "Show ladder entities: " "$showladderentities" [ showladderent
 menuitemcheckbox  "Show all playerstarts (spawn points): " "$showplayerstarts" [ showplayerstarts $arg1 ]
 menuitemslider    "Show closest ent slot info: " 0 2 "$hideeditslotinfo" [ always "if unassigned" never ][ hideeditslotinfo $arg1 ] 1
 menuitemcheckbox  "Show edit info panel: " "(! $hideeditinfopanel)" [ hideeditinfopanel (! $arg1) ]
-menuitemradio     "Entity selection" 0 1 "(pointatent)" ["Closest entity" "Point at entity"] [ pointatent $arg1 ] 0
+menuitemradio     "Entity selection: " 0 1 "$pointatent" ["Closest entity" "Point at entity"] [ pointatent $arg1 ] 0
 menuitemslider    "Fly speeds multiplier: " 1 5 "$flyspeed" 1 [ flyspeed $arg1 ]
 menuitemcheckbox  "Write xmaps to disk on quit: " "$persistentxmaps" [ persistentxmaps $arg1 ]
 // opt/autosave.cfg may add some entries


### PR DESCRIPTION
It was printing text on the console whenever  "editing setting" menu was opened and after closing and opening AC the config did not keep the "pointatent" configuration.