### PR TITLE
Improve the crosshair color health algorithm

### DIFF
--- a/source/src/renderhud.cpp
+++ b/source/src/renderhud.cpp
@@ -229,8 +229,11 @@ void drawcrosshair(playerent *p, int n, color *c, float size)
         if(n==CROSSHAIR_TEAMMATE) glColor3ub(255, 0, 0);
         else if(!m_osok)
         {
-            if(p->health<=25) glColor3ub(255,0,0);
-            else if(p->health<=50) glColor3ub(255,128,0);
+            // color crosshair depending on health
+            if(p->health<=25) glColor3ub(255, 0, 0);
+            else if(p->health<=75) glColor3ub(255, (p->health-25)/50.0f * 255, 0);
+            else if(p->health<=99) glColor3ub(255, 255, (p->health-75)/25.0f * 255);
+            else glColor3ub(255, 255, 255);
         }
     }
     float s = size>0 ? size : (float)crosshairsize;


### PR DESCRIPTION
Inspired by https://github.com/tomatenquark/code/pull/49.

Instead of only having 3 states (red/orange/white), this changes the crosshair color smoothly depending on health remaining. The colors used at <= 25 and 50 HP remain identical to what they were before.