### PR TITLE
Use in-out easing for better animation interpolation

### DIFF
--- a/source/src/rendermodel.cpp
+++ b/source/src/rendermodel.cpp
@@ -1,6 +1,7 @@
 #include "cube.h"
 
-VARP(animationinterpolationtime, 0, 150, 1000);
+// 165 is the highest value that does not break player animations when firing the SMG
+VARP(animationinterpolationtime, 0, 165, 1000);
 
 model *loadingmodel = NULL;
 mapmodelattributes loadingattributes;

--- a/source/src/vertmodel.h
+++ b/source/src/vertmodel.h
@@ -887,7 +887,9 @@ struct vertmodel : model
             if(doai)
             {
                 prev.setframes(d->prev[index]);
-                ai_t = (lastmillis-d->lastanimswitchtime[index])/(float)animationinterpolationtime;
+                // use easeInOutSine easing for smoother appearance
+                // https://easings.net/#easeInOutSine
+                ai_t = -(cos(M_PI * (lastmillis-d->lastanimswitchtime[index])/(float)animationinterpolationtime) - 1) / 2;
             }
 
             glPushMatrix();


### PR DESCRIPTION
Inspired by https://github.com/redeclipse/base/pull/1330.

The difference is mainly noticeable on high refresh-rate monitors nd only affects third-person animations.

The animation interpolation duration has been slightly lengthened o better make use of the new easing.