### PR TITLE
Fix deadlock in signal handler

### DIFF
--- a/source/src/tools.cpp
+++ b/source/src/tools.cpp
@@ -391,7 +391,7 @@ struct signalbinder
         {
             backtrace_symbols_fd(array, n, 1);
 #if !defined(STANDALONE)
-            if(clientlogfile) backtrace_symbols_fd(array, n, 1);
+            if(clientlogfile) backtrace_symbols_fd(array, n, fileno(clientlogfile->file));
 #endif
         }
 

--- a/source/src/tools.cpp
+++ b/source/src/tools.cpp
@@ -387,15 +387,13 @@ struct signalbinder
         const int BTSIZE = 25;
         void *array[BTSIZE];
         int n = backtrace(array, BTSIZE);
-        char **symbols = backtrace_symbols(array, n);
         for(int i = 0; i < n; i++)
         {
-            printf("%s\n", symbols[i]);
+            backtrace_symbols_fd(array, n, 1);
 #if !defined(STANDALONE)
-            if(clientlogfile) clientlogfile->printf("%s\n", symbols[i]);
+            if(clientlogfile) backtrace_symbols_fd(array, n, 1);
 #endif
         }
-        free(symbols);
 
         fatal("AssaultCube error (%d)", sig);
 


### PR DESCRIPTION
This PR will fix #413. It uses the `backtrace_symbols_fd` function, which is safe to use in signal handlers.

TODO:
- [ ] Test