### PR TITLE
Modifications to gun reload behavior

### DIFF
--- a/source/src/clientgame.cpp
+++ b/source/src/clientgame.cpp
@@ -617,6 +617,7 @@ void showrespawntimer()
     if(m_arena)
     {
         if(!arenaintermission) return;
+        if (player1->weaponsel) player1->weaponsel->cancelreload();
         showhudtimer(5, arenaintermission, "FIGHT!", lastspawnattempt >= arenaintermission && lastmillis < lastspawnattempt+100);
     }
     else if(player1->state==CS_DEAD && m_flags_ && (!player1->isspectating() || player1->spectatemode==SM_DEATHCAM))

--- a/source/src/weapon.cpp
+++ b/source/src/weapon.cpp
@@ -989,7 +989,7 @@ bool weapon::reload(bool autoreloaded)
 
 void weapon::cancelreload()
 {
-    gunwait = reloading = reloadbullets = 0;
+    reloading = reloadbullets = 0;
 }
 
 VARP(oldfashionedgunstats, 0, 0, 1);

--- a/source/src/weapon.h
+++ b/source/src/weapon.h
@@ -18,19 +18,20 @@ struct weapon
     virtual int dynspread();
     virtual float dynrecoil();
     int reloading, lastaction;
+    int reloadbullets = 0;
 
     virtual bool attack(vec &targ) = 0;
     virtual void attackfx(const vec &from, const vec &to, int millis) = 0;
     virtual void attackphysics(vec &from, vec &to);
     virtual void attacksound();
     virtual bool reload(bool autoreloaded);
+    virtual void cancelreload();
     virtual void reset() {}
     virtual bool busy() { return false; }
 
     virtual int modelanim() = 0;
     virtual void updatetimers(int millis);
     virtual bool selectable();
-    virtual bool deselectable();
     virtual void renderstats();
     virtual void renderhudmodel();
     virtual void renderaimhelp(bool teamwarning);


### PR DESCRIPTION
This PR makes it so you can cancel reloading by switching to another weapon. The current AC behavior prevents you from switching weapons while you're reloading, so if someone comes around the corner during a reload you just die. The new behavior in this PR enables you to at least have a chance of fighting back.

In order to accomplish this, I made it so the values for the magazine and ammo aren't updated until after the reload completes (instead of before the reload starts, which is the current behavior). That way, if you switch to another weapon, the reload can just be canceled.

Also, I have disallowed reloading when the game is in the arena intermission state. This is because the player could end up with more ammo in their magazine than the size of the magazine by reloading right before the intermission ends. The reload could complete after the new round starts, when the magazine had already been filled, resulting in the magazine being filled over its capacity.

This new reloading behavior is working, I have tested it quite a lot and hammered out the bugs. The only remaining problem is that I haven't yet figured out how to stop the reloading sound from playing when the reload gets canceled. So if you reload your gun, then interrupt it by switching to your knife, the reload sound still plays the rest of the way through. I'm going to work on fixing that, but I wanted to get this PR open to see what you guys thought about it.