### PR TITLE
Raise max download size from 1 to 2 MB

### DIFF
--- a/source/src/http.cpp
+++ b/source/src/http.cpp
@@ -18,7 +18,7 @@ void httpget::reset(int keep) // keep == 0: delete all, keep == 1: keep connecti
         ip.host = ENET_HOST_ANY;
         ip.port = 80;         // change manually, if needed
         maxredirects = 3;
-        maxtransfer = maxsize = 1<<20; // 1 MB (caps transfer size and unzipped size)
+        maxtransfer = maxsize = 2<<20; // 2 MB (caps transfer size and unzipped size)
         connecttimeout = 6000;
         disconnect();
     }


### PR DESCRIPTION
Downloads of unzipped files hosted on packages.cubers.net or other package-servers will be dismissed if those exceed the maximum size of 1 MB. This change raises the threshold to 2 MB, allowing larger files to be downloaded successfully.

The 1 MB limit used to be in place ever since, but wasn't preventing larger files from being downloaded in versions prior to v1.3 (bug?). Therefore we now already have files hosted on the package-server, which exceed 1 MB (and are smaller than 2 MB).

In order to maintain the user experience and spare contributors reworking the files in question, this raise of the limit would fix the current issues.