### PR TITLE
Revert PR #176

### DIFF
--- a/config/docs.cfg
+++ b/config/docs.cfg
@@ -956,7 +956,6 @@ docref [resetzones];
 docref [survival];
 docident [dropflag] [Drops the taken flag.];
 dockey [BACKSPACE] [Backspace] [];
-dockey [X] [] [];
 docident [findcn] [Finds client number (cn) of player with given name.];
 docargument [N] [player name] [] [0];
 docident [flyspeed] [Determines by how much to multiply the fly speeds by.];

--- a/config/resetbinds.cfg
+++ b/config/resetbinds.cfg
@@ -183,7 +183,7 @@ editbind U undo
 bind V key_showmenuvoicecom
 editbind V paste
 bind W forward
-bind X [dropflag]
+bind X []
 editbind X editkey_scroll_walluppertex
 bind Y key_teamchat
 bind Z []

--- a/docs/reference.xml
+++ b/docs/reference.xml
@@ -3015,7 +3015,6 @@ name="AssaultCube Documentation" version="Current" xsi:schemaLocation="xml/cuber
           <description>Drops the taken flag.</description>
           <defaultKeys>
             <key alias="BACKSPACE" name="Backspace"/>
-            <key alias="X"/>
           </defaultKeys>
         </command>
 


### PR DESCRIPTION
Several people in the community would rather that the X bind remain null and allow only the backspace key to be binded to the dropflag function by default.