### PR TITLE
Use the right length for packet buffer on normal gamemode votes other than coop

### DIFF
--- a/source/src/server.cpp
+++ b/source/src/server.cpp
@@ -3955,7 +3955,7 @@ void process(ENetPacket *packet, int sender, int chan)
                     }
                     else
                     {
-                        packetbuf p(MAXTRANS + sg->coop_cgzlen + sg->coop_cfglengz, ENET_PACKET_FLAG_RELIABLE);
+                        packetbuf p(MAXTRANS + sg->curmap->cgzlen + sg->curmap->cfggzlen, ENET_PACKET_FLAG_RELIABLE);
                         putint(p, SV_RECVMAP);
                         sendstring(sg->smapname, p);
                         putint(p, sg->curmap->cgzlen);


### PR DESCRIPTION
sg->coop_cgzlen & sg->coop_cfglengz allways 0 other than coop gamemode

<img width="1103" height="201" alt="Képernyőkép 2025-08-24 120125" src="https://github.com/user-attachments/assets/fd90d5f0-248c-490b-98f6-0a8cb0807328" />
